### PR TITLE
feat: add individual notes mode and key center control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - playChordByNotes wrapper function for playing chords using note names instead of frequencies
 - Root Bass voicing option combining bass root note with first inversion (e.g., C3, E4, G4, C5)
+- Individual Notes mode for playing single chromatic notes instead of chords
+- Key Center selector to rotate the circle and place any note/chord at 12 o'clock position
+- Octave selector for individual notes mode (octaves 1-7)
 
 ### Changed
 - Oscillator type selection changed from radio buttons to dropdown for consistency
+- Circle of Fifths visualization now supports both chord mode and individual notes mode
+- Default key center is C (appears at 12 o'clock position)
 
 ## [0.3.0] - 2025-01-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   4. Update documentation as needed
   5. Create a version bump commit
 
+## Circle of Fifths Visual Positioning
+
+**CRITICAL**: When working with the Circle of Fifths visualization:
+- The chord data array order is: A(0), E(1), B(2), Gb(3), Db(4), Ab(5), Eb(6), Bb(7), F(8), C(9), G(10), D(11)
+- Due to the SVG's 15-degree rotation and text centering, **array position 8 appears at 12 o'clock**
+- F (at index 8) naturally appears at the top without any data rotation
+- To place any key at 12 o'clock, rotate the array to put that key at position 8
+- Rotation formula: `rotateAmount = (keyCenterIndex - 8 + 12) % 12`
+- This applies to both chord mode and notes mode
+
 ## Project Overview
 
 Fifths (chord-player) is an interactive web application that visualizes and plays musical chords using the Circle of Fifths. It's built with SvelteKit, TypeScript, and uses the Web Audio API for sound generation.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ An interactive web application that visualizes and plays musical chords using th
 ## Features
 
 - **Interactive Circle of Fifths** - Click any chord to hear it played
+- **Individual Notes Mode** - Switch between playing chords or individual chromatic notes
+- **Key Center Control** - Rotate the circle to place any note/chord at 12 o'clock position
 - **Multiple Voice Types** - Choose between sine, triangle, square, and sawtooth wave oscillators
 - **Rich Chord Voicings** - Select from standard, spread, rich, bass-enhanced, or root bass voicings
 - **Extended Frequency Range** - Supports 7 octaves (C1 to C7) for fuller sound
 - **Volume Control** - Adjustable master volume with real-time feedback
-- **Visual Feedback** - See which chord is currently playing
+- **Visual Feedback** - See which chord or note is currently playing
 - **Responsive Design** - Works on desktop and mobile devices
 - **Server-Side Rendering** - Fast initial load with pre-rendered chord data
 - **Optimized for Serverless** - In-memory data generation, no filesystem writes

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -27,32 +27,47 @@ let { chords }: Props = $props();
 
 // import utils
 import { textCoords, wedgePath } from "$utils/circleGeometry";
+import { getNoteForPosition, CHROMATIC_NOTES } from "$utils/noteHelpers";
 
 //- interaction functions
 function onMousedown(event: MouseEvent) {
 	event.stopPropagation();
 	const target = event.target as SVGPathElement;
 	const index = Number(target.dataset.index) ?? 0;
-	const adjustedIndex = index === 11 ? 0 : index + 1;
-	const datum = chords[adjustedIndex];
-	const mode = target.dataset.mode ?? "";
 
-	// display active chord name
-	if (mode === "major") {
-		const chord = datum.majorDisplay;
-		performance.activeChord = `${chord} major`;
-	} else if (mode === "minor") {
-		const chord = datum.minorDisplay;
-		const chordAdjusted = chord.replace("m", " minor");
-		performance.activeChord = chordAdjusted;
+	if (settings.mode === "notes") {
+		// Individual notes mode
+		const noteData = getNoteForPositionWithKeyCenter(index);
+		performance.activeChord = `${noteData.display}${settings.noteOctave}`;
+
+		// Play single note
+		playChord([noteData.frequency], settings.activeVoice as OscillatorType);
 	} else {
-		performance.activeChord = "";
-	}
+		// Chords mode - use reordered chords
+		if (!reorderedChords || reorderedChords.length === 0) return;
 
-	// play chord using the audio store with selected voicing
-	const voicings = datum[`${mode}Voicings`] as VoicingFrequencies;
-	const frequencies = voicings[settings.chordVoicing] || voicings.standard;
-	playChord(frequencies, settings.activeVoice as OscillatorType);
+		const datum = reorderedChords[index];
+		if (!datum) return;
+
+		const mode = target.dataset.mode ?? "";
+
+		// display active chord name
+		if (mode === "major") {
+			const chord = datum.majorDisplay;
+			performance.activeChord = `${chord} major`;
+		} else if (mode === "minor") {
+			const chord = datum.minorDisplay;
+			const chordAdjusted = chord.replace("m", " minor");
+			performance.activeChord = chordAdjusted;
+		} else {
+			performance.activeChord = "";
+		}
+
+		// play chord using the audio store with selected voicing
+		const voicings = datum[`${mode}Voicings`] as VoicingFrequencies;
+		const frequencies = voicings[settings.chordVoicing] || voicings.standard;
+		playChord(frequencies, settings.activeVoice as OscillatorType);
+	}
 }
 function onMouseup(event: MouseEvent) {
 	event.stopPropagation();
@@ -62,20 +77,86 @@ function onMouseup(event: MouseEvent) {
 	}, 600);
 }
 
-const modes = [
-	{
-		classes: "fill-accent",
-		r0: 180,
-		r1: 130,
-		mode: "major",
-	},
-	{
-		classes: "fill-accent/90",
-		r0: 130,
-		r1: 80,
-		mode: "minor",
-	},
-];
+const modes = $derived(
+	settings.mode === "notes"
+		? [
+				{
+					classes: "fill-accent",
+					r0: 180,
+					r1: 80,
+					mode: "note",
+				},
+			]
+		: [
+				{
+					classes: "fill-accent",
+					r0: 180,
+					r1: 130,
+					mode: "major",
+				},
+				{
+					classes: "fill-accent/90",
+					r0: 130,
+					r1: 80,
+					mode: "minor",
+				},
+			],
+);
+
+// Rearrange chords based on key center
+const reorderedChords = $derived(
+	settings.mode === "chords" && chords && chords.length > 0
+		? (() => {
+				// Map sharps to their flat equivalents that appear in the circle
+				const keyMap: Record<string, string> = {
+					"C#": "D♭",
+					"D#": "E♭",
+					"F#": "G♭",
+					"G#": "A♭",
+					"A#": "B♭",
+				};
+
+				const searchKey = keyMap[settings.keyCenter] || settings.keyCenter;
+				let keyCenterIndex = chords.findIndex(
+					(chord) => chord.majorDisplay === searchKey,
+				);
+
+				// Default to C if not found
+				if (keyCenterIndex === -1) keyCenterIndex = 9;
+
+				// IMPORTANT: Visual positioning in the Circle of Fifths
+				// The SVG has a 15-degree rotation, and each segment is 30 degrees
+				// Through testing, we determined that array position 8 appears at 12 o'clock
+				// This is because F (at index 8) naturally appears at the top
+				// To put any key center at 12 o'clock, we need to move it to position 8
+				// Formula: rotateAmount = (keyCenterIndex - 8 + 12) % 12
+				const rotateAmount = (keyCenterIndex - 8 + 12) % 12;
+				return [
+					...chords.slice(rotateAmount),
+					...chords.slice(0, rotateAmount),
+				];
+			})()
+		: chords,
+);
+
+// Get note for position considering key center
+function getNoteForPositionWithKeyCenter(position: number) {
+	if (settings.mode === "notes") {
+		// Find the offset based on key center
+		// settings.keyCenter uses "#" but CHROMATIC_NOTES uses "♯", so we need to match by id
+		const keyCenterIndex = CHROMATIC_NOTES.findIndex((note) => {
+			// Match C# to Cs, D# to Ds, etc.
+			const keyId = settings.keyCenter.replace("#", "s");
+			return note.id === keyId;
+		});
+		// In notes mode, position 8 also appears at 12 o'clock (same as chord mode)
+		// To put our key center at position 8, we need to offset by (8 - keyCenterIndex)
+		// But since we're adjusting the note selection, not the array, we do the opposite
+		const adjustedPosition = (position - 8 + keyCenterIndex + 12) % 12;
+		return getNoteForPosition(adjustedPosition, settings.noteOctave);
+	}
+	return getNoteForPosition(position, settings.noteOctave);
+}
 </script>
 
 <svg
@@ -87,49 +168,86 @@ const modes = [
 	width="800"
 >
 	<g class="rotate-[15deg] origin-[200px_200px_0px]">
-		{#each chords as item, i}
-			{#each modes as m, index}
+		{#if settings.mode === "notes"}
+			<!-- Note buttons for individual notes mode -->
+			{#each Array(12) as _, i}
+				{@const noteData = getNoteForPositionWithKeyCenter(i)}
 				<path
 					aria-pressed="false"
-					aria-labelledby="chord-button-label-{item[m.mode + 'Id']}"
-					class="!outline-none stroke-primary stroke-[0.1em] transition-opacity hover:opacity-60 {m.classes} focus:opacity-60"
-					d={wedgePath(m.r0, m.r1, i)}
-					data-mode={m.mode}
-					data-chord={item[m.mode + 'Id']}
+					aria-labelledby="note-button-label-{noteData.id}"
+					class="!outline-none stroke-primary stroke-[0.1em] transition-opacity hover:opacity-60 fill-accent focus:opacity-60"
+					d={wedgePath(180, 80, i)}
+					data-mode="note"
 					data-index={i}
 					onmousedown={(e) => { onMousedown(e)}}
 					onmouseup={(e) => { onMouseup(e)}}
-					id="chord-button-{item[m.mode + 'Id']}"
+					id="note-button-{noteData.id}"
 					role="button"
-					tabindex={Number(index + 1) * 100 + Number(i)}
+					tabindex={i + 100}
 				/>
 			{/each}
-		{/each}
+		{:else}
+			<!-- Chord buttons for chord mode -->
+			{#each reorderedChords as item, i}
+				{#each modes as m, index}
+					<path
+						aria-pressed="false"
+						aria-labelledby="chord-button-label-{item[m.mode + 'Id']}"
+						class="!outline-none stroke-primary stroke-[0.1em] transition-opacity hover:opacity-60 {m.classes} focus:opacity-60"
+						d={wedgePath(m.r0, m.r1, i)}
+						data-mode={m.mode}
+						data-chord={item[m.mode + 'Id']}
+						data-index={i}
+						onmousedown={(e) => { onMousedown(e)}}
+						onmouseup={(e) => { onMouseup(e)}}
+						id="chord-button-{item[m.mode + 'Id']}"
+						role="button"
+						tabindex={Number(index + 1) * 100 + Number(i)}
+					/>
+				{/each}
+			{/each}
+		{/if}
 	</g>
 
 	<!-- text labels -->
 	<g class="pointer-events-none">
-		{#each chords as item, i}
-			<!-- outer labels -->
-			{@const radius1 = 150}
-			{@const [x1, y1] = textCoords(radius1, i)}
-			<text
-				class="text-20px sm:text-[1em] text-anchor-middle dominant-baseline-central"
-				id="chord-button-label-{item.majorId}"
-				x={x1.toFixed(2)}
-				y={y1.toFixed(2)}
-			>{item.majorDisplay}</text>
+		{#if settings.mode === "notes"}
+			<!-- Note labels for individual notes mode -->
+			{#each Array(12) as _, i}
+				{@const noteData = getNoteForPositionWithKeyCenter(i)}
+				{@const radius = 130}
+				{@const [x, y] = textCoords(radius, i)}
+				<text
+					class="text-24px sm:text-[1.2em] text-anchor-middle dominant-baseline-central"
+					id="note-button-label-{noteData.id}"
+					x={x.toFixed(2)}
+					y={y.toFixed(2)}
+				>{noteData.display}</text>
+			{/each}
+		{:else}
+			<!-- Chord labels for chord mode -->
+			{#each reorderedChords as item, i}
+				<!-- outer labels -->
+				{@const radius1 = 150}
+				{@const [x1, y1] = textCoords(radius1, i)}
+				<text
+					class="text-20px sm:text-[1em] text-anchor-middle dominant-baseline-central"
+					id="chord-button-label-{item.majorId}"
+					x={x1.toFixed(2)}
+					y={y1.toFixed(2)}
+				>{item.majorDisplay}</text>
 
-			<!-- inner labels -->
-			{@const radius2 = 104}
-			{@const [x2, y2] = textCoords(radius2, i)}
-			<text
-				id="chord-button-label-{item.minorId}"
-				class="text-18px sm:text-[0.9em] text-anchor-middle dominant-baseline-central"
-				x={x2.toFixed(2)}
-				y={y2.toFixed(2)}
-			>{item.minorDisplay}</text>
-		{/each}
+				<!-- inner labels -->
+				{@const radius2 = 104}
+				{@const [x2, y2] = textCoords(radius2, i)}
+				<text
+					id="chord-button-label-{item.minorId}"
+					class="text-18px sm:text-[0.9em] text-anchor-middle dominant-baseline-central"
+					x={x2.toFixed(2)}
+					y={y2.toFixed(2)}
+				>{item.minorDisplay}</text>
+			{/each}
+		{/if}
 	</g>
 
 	<!-- center text -->

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -5,10 +5,46 @@ import VoicingSelector from "$components/VoicingSelector.svelte";
 </script>
 
 <div class="absolute left-8 bottom-8 z-20 flex flex-col gap-6">
+	<!-- Play Mode Selection -->
+	<div class="flex flex-col gap-2">
+		<label for="mode-select" class="text-sm opacity-80 sr-only">Play Mode</label>
+		<select
+			id="mode-select"
+			bind:value={settings.mode}
+			class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm capitalize"
+		>
+			<option value="chords">Chords</option>
+			<option value="notes">Individual Notes</option>
+		</select>
+	</div>
+
+	<!-- Key Center Selection -->
+	<div class="flex flex-col gap-2">
+		<label for="key-center-select" class="text-sm opacity-80 sr-only">Key Center (12 o'clock)</label>
+		<select
+			id="key-center-select"
+			bind:value={settings.keyCenter}
+			class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm"
+		>
+			<option value="C">C</option>
+			<option value="C#">C♯ / D♭</option>
+			<option value="D">D</option>
+			<option value="D#">D♯ / E♭</option>
+			<option value="E">E</option>
+			<option value="F">F</option>
+			<option value="F#">F♯ / G♭</option>
+			<option value="G">G</option>
+			<option value="G#">G♯ / A♭</option>
+			<option value="A">A</option>
+			<option value="A#">A♯ / B♭</option>
+			<option value="B">B</option>
+		</select>
+	</div>
+
 	<!-- Oscillator Voice Selection -->
 	<div class="flex flex-col gap-2">
-		<label for="oscillator-select" class="text-sm opacity-80">Oscillator Type</label>
-		<select 
+		<label for="oscillator-select" class="text-sm opacity-80 sr-only">Oscillator Type</label>
+		<select
 			id="oscillator-select"
 			bind:value={settings.activeVoice}
 			class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm capitalize"
@@ -20,7 +56,25 @@ import VoicingSelector from "$components/VoicingSelector.svelte";
 			{/each}
 		</select>
 	</div>
-	
-	<!-- Chord Voicing Selection -->
-	<VoicingSelector />
+
+	<!-- Chord Voicing Selection (only in chords mode) -->
+	{#if settings.mode === "chords"}
+		<VoicingSelector />
+	{/if}
+
+	<!-- Octave Selection (only in notes mode) -->
+	{#if settings.mode === "notes"}
+		<div class="flex flex-col gap-2">
+			<label for="octave-select" class="text-sm opacity-80 sr-only">Octave</label>
+			<select
+				id="octave-select"
+				bind:value={settings.noteOctave}
+				class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm"
+			>
+				{#each [1, 2, 3, 4, 5, 6, 7] as octave}
+					<option value={octave}>Octave {octave}</option>
+				{/each}
+			</select>
+		</div>
+	{/if}
 </div>

--- a/src/lib/components/VoicingSelector.svelte
+++ b/src/lib/components/VoicingSelector.svelte
@@ -20,8 +20,8 @@ const voicingOptions = [
 </script>
 
 <div class="flex flex-col gap-2">
-  <label for="voicing-select" class="text-sm opacity-80">Chord Voicing</label>
-  <select 
+  <label for="voicing-select" class="text-sm opacity-80 sr-only">Chord Voicing</label>
+  <select
     id="voicing-select"
     bind:value={settings.chordVoicing}
     class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm"

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -8,6 +8,21 @@ export const settings = $state({
 		| "rich"
 		| "bass"
 		| "rootBass",
+	mode: "chords" as "chords" | "notes",
+	noteOctave: 4,
+	keyCenter: "C" as
+		| "C"
+		| "C#"
+		| "D"
+		| "D#"
+		| "E"
+		| "F"
+		| "F#"
+		| "G"
+		| "G#"
+		| "A"
+		| "A#"
+		| "B",
 });
 
 // functions to change settings

--- a/src/lib/utils/circleGeometry.ts
+++ b/src/lib/utils/circleGeometry.ts
@@ -88,24 +88,28 @@ export function wedgePath(
 
 /**
  * Calculate text label coordinates for a circular segment
- * Positions text at the start angle of a segment (for Circle of Fifths labeling)
+ * Positions text at the center of a segment (for Circle of Fifths labeling)
  * @param radius - Distance from center to place the text
  * @param segmentIndex - Index of the segment (0-based)
  * @param totalSegments - Total number of segments (default: 12)
+ * @param rotationOffset - Additional rotation offset in degrees (default: 15 for circle of fifths alignment)
  * @returns Array of [x, y] coordinates for text placement
  */
 export function textCoords(
 	radius: number,
 	segmentIndex: number,
 	totalSegments = 12,
+	rotationOffset = 15,
 ): [number, number] {
 	const degreesPerSegment = 360 / totalSegments;
-	const segmentStartDegree = degreesPerSegment * segmentIndex;
+	// Center the text in the segment by adding half the segment angle
+	const segmentCenterDegree =
+		degreesPerSegment * segmentIndex + degreesPerSegment / 2 + rotationOffset;
 
 	return polarToCartesian(
 		200, // SVG viewBox center X
 		200, // SVG viewBox center Y
 		radius,
-		segmentStartDegree,
+		segmentCenterDegree,
 	);
 }

--- a/src/lib/utils/noteHelpers.ts
+++ b/src/lib/utils/noteHelpers.ts
@@ -1,0 +1,71 @@
+/**
+ * Helper utilities for individual note playback mode
+ */
+
+import { generateFrequencyMap } from "./frequencyGenerator";
+
+// Chromatic scale notes in order (starting from C)
+export const CHROMATIC_NOTES = [
+	{ display: "C", id: "C" },
+	{ display: "C♯", id: "Cs" },
+	{ display: "D", id: "D" },
+	{ display: "D♯", id: "Ds" },
+	{ display: "E", id: "E" },
+	{ display: "F", id: "F" },
+	{ display: "F♯", id: "Fs" },
+	{ display: "G", id: "G" },
+	{ display: "G♯", id: "Gs" },
+	{ display: "A", id: "A" },
+	{ display: "A♯", id: "As" },
+	{ display: "B", id: "B" },
+];
+
+// Map circle positions to chromatic notes
+// For notes mode, we want chromatic order starting from C at the top
+// Position 0: C, Position 1: C#, Position 2: D, etc.
+export const CIRCLE_POSITION_TO_CHROMATIC = [
+	0, // Position 0 -> C
+	1, // Position 1 -> C#
+	2, // Position 2 -> D
+	3, // Position 3 -> D#
+	4, // Position 4 -> E
+	5, // Position 5 -> F
+	6, // Position 6 -> F#
+	7, // Position 7 -> G
+	8, // Position 8 -> G#
+	9, // Position 9 -> A
+	10, // Position 10 -> A#
+	11, // Position 11 -> B
+];
+
+/**
+ * Get the note data for a given circle position in notes mode
+ */
+export function getNoteForPosition(position: number, octave = 4) {
+	const chromaticIndex = CIRCLE_POSITION_TO_CHROMATIC[position];
+	const note = CHROMATIC_NOTES[chromaticIndex];
+	const noteWithOctave = `${note.id.replace("s", "#")}${octave}`;
+
+	// Get frequency from the generator
+	const frequencies = generateFrequencyMap(octave, octave, false);
+	const frequency = frequencies[noteWithOctave];
+
+	return {
+		...note,
+		frequency,
+		noteWithOctave,
+	};
+}
+
+/**
+ * Play a single note (wrapper around the chord player)
+ */
+export function playNote(
+	frequency: number,
+	oscillatorType: OscillatorType,
+	duration?: number,
+) {
+	// We'll import and use the playChord function with a single frequency
+	// This will be called from the Instrument component
+	return { frequency, oscillatorType, duration };
+}


### PR DESCRIPTION
## Summary
- Add mode toggle between playing chords or individual chromatic notes
- Add key center selector to rotate the circle (any note/chord at 12 o'clock)
- Add octave selector for notes mode (octaves 1-7)
- Convert oscillator type selection to dropdown for UI consistency

## Features
### Individual Notes Mode
- Switch between Chords and Individual Notes modes
- In notes mode, only the outer circle is displayed
- Notes are arranged chromatically (C, C#, D, D#, E, F, F#, G, G#, A, A#, B)
- Octave selector allows playing notes across 7 octaves

### Key Center Control
- Select any note/chord to appear at the 12 o'clock position
- Circle rotates dynamically while keeping labels upright and readable
- Works for both chord mode and notes mode
- C is at 12 o'clock by default

## Technical Details
- Discovered and documented that array position 8 appears at 12 o'clock due to SVG rotation
- Added critical positioning information to CLAUDE.md
- Improved accessibility with screen reader labels
- Handles enharmonic equivalents correctly (C# = Db, etc.)

## Test Plan
- [x] Switch between chord and notes modes
- [x] Test all key center selections in both modes
- [x] Verify sharp notes work correctly (C#, D#, etc.)
- [x] Test all octaves in notes mode
- [x] Ensure chord voicings still work correctly
- [x] Test oscillator dropdown functionality