### PR TITLE
feat: add touch-responsive chord and note playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2025-01-22
+
+### Added
+- Touch-responsive chord and note playback - sounds play for the duration of key press
+- Continuous audio playback with startChord() and stopChord() methods in audio store
+- Full touch event support (touchstart, touchend, touchcancel) for mobile devices
+- Mouse leave event handling to stop playback when cursor exits chord/note
+
+### Changed
+- Chords and notes now play continuously while pressed instead of fixed 1.5 second duration
+- Improved audio responsiveness with faster attack (10ms) and release (50ms) times
+- Added touch-none CSS class to prevent touch scrolling interference during playback
+
 ## [0.3.2] - 2025-01-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.3.2
+**Current Version**: 0.3.3
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An interactive web application that visualizes and plays musical chords using th
 ## Features
 
 - **Interactive Circle of Fifths** - Click any chord to hear it played
+- **Touch-Responsive Playback** - Press and hold to play chords/notes for as long as you hold
 - **Individual Notes Mode** - Switch between playing chords or individual chromatic notes
 - **Key Center Control** - Rotate the circle to place any note/chord at 12 o'clock position
 - **Multiple Voice Types** - Choose between sine, triangle, square, and sawtooth wave oscillators
@@ -14,7 +15,7 @@ An interactive web application that visualizes and plays musical chords using th
 - **Extended Frequency Range** - Supports 7 octaves (C1 to C7) for fuller sound
 - **Volume Control** - Adjustable master volume with real-time feedback
 - **Visual Feedback** - See which chord or note is currently playing
-- **Responsive Design** - Works on desktop and mobile devices
+- **Responsive Design** - Works on desktop and mobile devices with full touch support
 - **Server-Side Rendering** - Fast initial load with pre-rendered chord data
 - **Optimized for Serverless** - In-memory data generation, no filesystem writes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@sveltejs/adapter-vercel": "^5.7.0",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -82,5 +82,5 @@ import VoicingSelector from "$components/VoicingSelector.svelte";
 	{/if}
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.3.2</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.3.3</div>
 </div>


### PR DESCRIPTION
## Summary
- Implemented touch-responsive playback where chords/notes play continuously while pressed
- Added full touch event support for mobile devices
- Improved audio responsiveness with faster attack/release times

## Changes
- Added `startChord()` and `stopChord()` methods to audio store for continuous playback
- Updated Instrument component to handle both mouse and touch events
- Added `onmouseleave` handler to stop playback when cursor exits
- Implemented touch event handlers: `ontouchstart`, `ontouchend`, `ontouchcancel`
- Improved audio envelope with 10ms attack and 50ms release for better responsiveness
- Added `touch-none` CSS class to prevent touch scrolling interference

## Test plan
- [x] Test mouse press and hold on desktop browser
- [x] Test touch press and hold on mobile device
- [x] Verify audio starts immediately on press
- [x] Verify audio stops immediately on release
- [x] Test mouse leave behavior (audio should stop)
- [x] Test touch cancel behavior (audio should stop)
- [x] Verify no audio clicks or pops
- [x] Test with different oscillator types and voicings

## Version
Bumped to v0.3.3