### PR TITLE
fix: stuck chord when sliding between wedges (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-07-11
+
+### Fixed
+- Sliding from a held chord to another wedge left the second chord stuck on (unstoppable even after release): the first chord's fade-out cleanup deleted the pointer's tracking entry after the replacement chord had reused it, orphaning the new oscillators. The cleanup now only removes the entry if it still belongs to the chord being cleaned up.
+- Releasing the very first press before the 150ms audio-unlock delay elapsed started the chord after the pointer was already up, sticking it on. The pointer is now tracked immediately, so an early release cancels the pending chord.
+
 ## [0.5.0] - 2026-07-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.0
+**Current Version**: 0.5.1
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -181,26 +181,6 @@ function onPressStart(event: PointerEvent) {
 		}
 	}
 
-	// Initialize audio on very first interaction
-	if (!hasInitializedAudio) {
-		hasInitializedAudio = true;
-		unlockAudio();
-
-		// Delay first chord to let audio initialize
-		setTimeout(() => {
-			// Track this pointer
-			activePointers.set(pointerId, {
-				element: target,
-				elementId: target.id,
-				chordName: "",
-				seventh: false,
-			});
-			currentPointerId = pointerId;
-			playChordFromElement(target, pointerId);
-		}, 150);
-		return;
-	}
-
 	// Track this pointer with empty chord name initially
 	activePointers.set(pointerId, {
 		element: target,
@@ -209,6 +189,21 @@ function onPressStart(event: PointerEvent) {
 		seventh: false,
 	});
 	currentPointerId = pointerId;
+
+	// Initialize audio on very first interaction, delaying the first chord
+	// to let the context unlock. The pointer is already tracked above, so a
+	// release during the delay removes it and the pending chord never plays
+	// (otherwise it would start after the finger lifted and stick on).
+	if (!hasInitializedAudio) {
+		hasInitializedAudio = true;
+		unlockAudio();
+		setTimeout(() => {
+			if (activePointers.has(pointerId)) {
+				playChordFromElement(target, pointerId);
+			}
+		}, 150);
+		return;
+	}
 
 	// Play the new chord with this pointer ID
 	playChordFromElement(target, pointerId);

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -210,6 +210,22 @@ describe("Instrument", () => {
 			expect(performanceStore.activeChord).toBe("");
 		});
 
+		// Regression: releasing before the 150ms unlock delay elapsed used to
+		// start the chord after the pointer was already up, sticking it on
+		it("does not start a chord if the pointer is released during the unlock delay", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			if (!cWedge) throw new Error("C wedge not found");
+
+			cWedge.dispatchEvent(pointerEvent("pointerdown", 1));
+			cWedge.dispatchEvent(pointerEvent("pointerup", 1));
+			vi.advanceTimersByTime(FIRST_INTERACTION_DELAY_MS);
+			await tick();
+
+			expect(startChord).not.toHaveBeenCalled();
+			expect(performanceStore.activeChord).toBe("");
+		});
+
 		it("first pointerdown delays playback by 150ms (audio unlock), then starts the chord", async () => {
 			const { container } = render(Instrument, { chords: chordsData });
 			const cWedge = container.querySelector('[id="chord-button-C"]');

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -113,5 +113,5 @@ import { settings } from "$stores/settings.svelte";
 	{/if}
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.1</div>
 </div>

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -275,6 +275,33 @@ describe("audio store", () => {
 			expect(audio.audioState.isPlaying).toBe(false);
 		});
 
+		// Regression: sliding between wedges restarts the chord under the same
+		// pointer ID while the previous chord's fade cleanup is still pending.
+		// That cleanup used to delete the pointer's map entry unconditionally,
+		// orphaning the replacement chord as an unstoppable drone.
+		it("does not orphan a replacement chord started during the fade cleanup window", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1); // press chord A
+			await audio.startChord(A_MINOR, "sine", 1); // slide to chord B
+
+			// Chord A's cleanup timer fires while B is sounding
+			vi.advanceTimersByTime(CLEANUP_MS);
+
+			// Releasing the pointer must still stop chord B
+			const ctx = FakeAudioContext.instances[0];
+			const chordBOscillators = ctx.createdOscillators.slice(C_MAJOR.length);
+			expect(chordBOscillators).toHaveLength(A_MINOR.length);
+
+			audio.stopChordById(1);
+			for (const osc of chordBOscillators) {
+				expect(osc.stop).toHaveBeenCalled();
+			}
+
+			vi.advanceTimersByTime(CLEANUP_MS);
+			expect(audio.audioState.isPlaying).toBe(false);
+			expect(audio.audioState.activeNoteCount).toBe(0);
+		});
+
 		it("keeps other pointers' chords playing", async () => {
 			const audio = await freshStore();
 			await audio.startChord(C_MAJOR, "sine", 1);

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -265,7 +265,13 @@ export function stopChordById(pointerId: number): void {
 			} catch {
 				// Already disconnected
 			}
-			activeChords.delete(pointerId);
+			// Only remove the map entry if it still belongs to the chord being
+			// cleaned up — a replacement chord (e.g. sliding between wedges)
+			// may have reused this pointer ID while the fade was in flight,
+			// and deleting its entry would orphan it as an unstoppable drone
+			if (activeChords.get(pointerId) === chord) {
+				activeChords.delete(pointerId);
+			}
 			audioState.activeNoteCount = activeOscillators.size;
 			audioState.isPlaying = activeOscillators.size > 0;
 		},


### PR DESCRIPTION
## Summary

Fixes the desktop bug where click-holding a chord and dragging onto a different wedge left the second chord stuck on — unstoppable even after releasing the mouse.

**Root cause**: sliding restarts the chord under the same pointer ID while the previous chord's 100ms fade-out cleanup is still pending. That cleanup deleted the pointer's `activeChords` entry unconditionally, clobbering the replacement chord's entry. The release then found nothing to stop, orphaning the new oscillators as a drone. The cleanup now removes the entry only if it still belongs to the chord being cleaned up.

Also hardens an adjacent race found while fixing it: releasing the very first press before the 150ms audio-unlock delay elapsed started the chord *after* the pointer was up, sticking it on. The pointer is now tracked before the delay, so an early release cancels the pending chord.

## Test plan
- [x] Regression tests for both races (185 tests passing)
- [x] svelte-check, biome ci, fallow audit, build all clean
- [ ] Manual: click-hold a chord, drag across several wedges, release — silence