### PR TITLE
fix: desktop hint for seventh-chord activation (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-07-11
+
+### Fixed
+- The on-screen "7" pad was confusing on desktop — with a single mouse there is no way to hold it and click a chord at the same time. Mouse/trackpad users (detected via `hover: hover` and `pointer: fine`) now see a "hold ⇧ Shift" hint beside the pad, and the pad lights up while Shift is held, acting as an indicator. Touch devices are unchanged (the hint is hidden; holding the pad remains the mechanism).
+
 ## [0.5.1] - 2026-07-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.1
+**Current Version**: 0.5.2
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -113,5 +113,5 @@ import { settings } from "$stores/settings.svelte";
 	{/if}
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.1</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.2</div>
 </div>

--- a/src/lib/components/SeventhPad.svelte
+++ b/src/lib/components/SeventhPad.svelte
@@ -33,19 +33,42 @@ function onKeyUp(event: KeyboardEvent) {
 }
 </script>
 
-<button
-	type="button"
-	aria-pressed={performance.seventhHeld}
-	aria-label="Hold for seventh chords"
-	title="Hold for seventh chords (or hold Shift)"
-	class="select-none touch-none rounded-md border border-neutral-100/30 px-4 py-2 text-sm font-500 leading-none transition-colors {performance.seventhHeld
-		? 'bg-accent text-primary border-accent'
-		: 'bg-primary/20 hover:border-neutral-100/60'}"
-	onpointerdown={press}
-	onpointerup={release}
-	onpointercancel={release}
-	onpointerleave={release}
-	onkeydown={onKeyDown}
-	onkeyup={onKeyUp}
-	oncontextmenu={(e) => e.preventDefault()}
->{label}</button>
+<div class="flex items-center gap-2">
+	<button
+		type="button"
+		aria-pressed={performance.seventhHeld}
+		aria-label="Hold for seventh chords"
+		title="Hold for seventh chords (or hold Shift)"
+		class="select-none touch-none rounded-md border border-neutral-100/30 px-4 py-2 text-sm font-500 leading-none transition-colors {performance.seventhHeld
+			? 'bg-accent text-primary border-accent'
+			: 'bg-primary/20 hover:border-neutral-100/60'}"
+		onpointerdown={press}
+		onpointerup={release}
+		onpointercancel={release}
+		onpointerleave={release}
+		onkeydown={onKeyDown}
+		onkeyup={onKeyUp}
+		oncontextmenu={(e) => e.preventDefault()}
+	>{label}</button>
+
+	<!-- Desktop hint: with one mouse you can't hold the pad and click a
+	     chord, so tell mouse users about the keyboard modifier. The pad
+	     still lights up while Shift is held (it reflects the same state).
+	     Hidden on touch devices, where holding the pad is the mechanism. -->
+	<span class="seventh-desktop-hint items-center gap-1.5 text-xs opacity-60" aria-hidden="true">
+		hold
+		<kbd class="rounded border border-neutral-100/40 px-1.5 py-0.5 font-mono text-[11px] leading-none">⇧ Shift</kbd>
+	</span>
+</div>
+
+<style>
+	/* Only mouse/trackpad users can't hold the pad while playing */
+	.seventh-desktop-hint {
+		display: none;
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.seventh-desktop-hint {
+			display: inline-flex;
+		}
+	}
+</style>

--- a/src/lib/components/SeventhPad.svelte.test.ts
+++ b/src/lib/components/SeventhPad.svelte.test.ts
@@ -24,6 +24,14 @@ describe("SeventhPad", () => {
 		expect(pad()).toHaveTextContent("7");
 	});
 
+	it("renders the desktop Shift hint (visibility is media-query gated)", () => {
+		const { container } = render(SeventhPad);
+		const hint = container.querySelector(".seventh-desktop-hint");
+		expect(hint).toBeInTheDocument();
+		expect(hint).toHaveTextContent("hold");
+		expect(hint?.querySelector("kbd")).toHaveTextContent("Shift");
+	});
+
 	it("labels itself maj7 when the seventh type setting is major7", async () => {
 		settings.seventhType = "major7";
 		render(SeventhPad);


### PR DESCRIPTION
## Summary

On desktop the on-screen "7" pad was confusing: with a single mouse there's no way to hold the pad and click a chord at the same time.

Mouse/trackpad users (`@media (hover: hover) and (pointer: fine)`) now see a **hold ⇧ Shift** hint beside the pad, and the pad lights up while Shift is held (it reflects the same modifier state), so on desktop it acts as an indicator rather than a control. Touch devices are unchanged — the hint is hidden and holding the pad remains the mechanism.

## Test plan
- [x] 186 tests passing (new test for the hint markup)
- [x] svelte-check, biome ci, build clean
- [ ] Manual: desktop shows the Shift hint and the pad lights while Shift is held; phone shows no hint