### PR TITLE
fix: touch-only 7 pad, plain Shift note on desktop (v0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-07-11
+
+### Changed
+- The "7" pad is now touch-only: it is hidden entirely on mouse/trackpad devices, replaced by a plain text note on its own line at the bottom of the screen — "Hold down Shift to play 7th chords" (shown in chords mode only). This removes the confusing state where the pad appeared interactive on desktop but couldn't be used with a single mouse.
+
 ## [0.5.2] - 2026-07-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.2
+**Current Version**: 0.5.3
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -113,5 +113,5 @@ import { settings } from "$stores/settings.svelte";
 	{/if}
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.2</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.3</div>
 </div>

--- a/src/lib/components/SeventhPad.svelte
+++ b/src/lib/components/SeventhPad.svelte
@@ -33,12 +33,15 @@ function onKeyUp(event: KeyboardEvent) {
 }
 </script>
 
-<div class="flex items-center gap-2">
+<!-- Touch-only: with a single mouse there is no way to hold the pad and
+     click a chord, so desktop users get a plain Shift hint instead (see
+     +page.svelte) and never see this button. -->
+<div class="seventh-pad">
 	<button
 		type="button"
 		aria-pressed={performance.seventhHeld}
 		aria-label="Hold for seventh chords"
-		title="Hold for seventh chords (or hold Shift)"
+		title="Hold for seventh chords"
 		class="select-none touch-none rounded-md border border-neutral-100/30 px-4 py-2 text-sm font-500 leading-none transition-colors {performance.seventhHeld
 			? 'bg-accent text-primary border-accent'
 			: 'bg-primary/20 hover:border-neutral-100/60'}"
@@ -50,25 +53,13 @@ function onKeyUp(event: KeyboardEvent) {
 		onkeyup={onKeyUp}
 		oncontextmenu={(e) => e.preventDefault()}
 	>{label}</button>
-
-	<!-- Desktop hint: with one mouse you can't hold the pad and click a
-	     chord, so tell mouse users about the keyboard modifier. The pad
-	     still lights up while Shift is held (it reflects the same state).
-	     Hidden on touch devices, where holding the pad is the mechanism. -->
-	<span class="seventh-desktop-hint items-center gap-1.5 text-xs opacity-60" aria-hidden="true">
-		hold
-		<kbd class="rounded border border-neutral-100/40 px-1.5 py-0.5 font-mono text-[11px] leading-none">⇧ Shift</kbd>
-	</span>
 </div>
 
 <style>
-	/* Only mouse/trackpad users can't hold the pad while playing */
-	.seventh-desktop-hint {
-		display: none;
-	}
+	/* Hide the pad for mouse/trackpad users — Shift is their modifier */
 	@media (hover: hover) and (pointer: fine) {
-		.seventh-desktop-hint {
-			display: inline-flex;
+		.seventh-pad {
+			display: none;
 		}
 	}
 </style>

--- a/src/lib/components/SeventhPad.svelte.test.ts
+++ b/src/lib/components/SeventhPad.svelte.test.ts
@@ -24,12 +24,9 @@ describe("SeventhPad", () => {
 		expect(pad()).toHaveTextContent("7");
 	});
 
-	it("renders the desktop Shift hint (visibility is media-query gated)", () => {
+	it("wraps the pad so fine-pointer devices can hide it (touch-only control)", () => {
 		const { container } = render(SeventhPad);
-		const hint = container.querySelector(".seventh-desktop-hint");
-		expect(hint).toBeInTheDocument();
-		expect(hint).toHaveTextContent("hold");
-		expect(hint?.querySelector("kbd")).toHaveTextContent("Shift");
+		expect(container.querySelector(".seventh-pad")).toBeInTheDocument();
 	});
 
 	it("labels itself maj7 when the seventh type setting is major7", async () => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,6 +55,12 @@ let menuState: "closed" | "open" = $state("closed");
 
 </main>
 
+<!-- desktop-only seventh hint (the touch pad is hidden on fine-pointer
+     devices; see SeventhPad.svelte) -->
+{#if settings.mode === "chords"}
+	<p class="seventh-hint fixed bottom-4 inset-x-0 text-center text-sm opacity-60 pointer-events-none z-10 text-neutral-50">Hold down Shift to play 7th chords</p>
+{/if}
+
 
 
 
@@ -66,3 +72,15 @@ let menuState: "closed" | "open" = $state("closed");
 <!-- <footer class="text-12px px-8 py-4 border-t border-t-neutral-100/30 bg-black/10">
 	<div class="flex opacity-60">MIT License</div>
 </footer> -->
+
+<style>
+	/* The Shift hint only makes sense for mouse/trackpad users */
+	.seventh-hint {
+		display: none;
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.seventh-hint {
+			display: block;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

The on-screen "7" pad is now touch-only. On mouse/trackpad devices it's hidden entirely — a single mouse can't hold it and click a chord, so it read as broken/glitchy there. Desktop users instead get a plain text line at the bottom of the screen: **"Hold down Shift to play 7th chords"** (chords mode only, hidden on touch via media query).

## Test plan
- [x] 186 tests passing
- [x] svelte-check, biome ci, build clean; note verified present in prerendered output
- [ ] Manual: desktop shows only the bottom note (no pad); phone shows only the pad