### PR TITLE
chore: seventh hint copy tweak (v0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2026-07-12
+
+### Changed
+- Desktop seventh hint copy: "Shift + click to play 7th chords"
+
 ## [0.5.3] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.3
+**Current Version**: 0.5.4
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -113,5 +113,5 @@ import { settings } from "$stores/settings.svelte";
 	{/if}
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.3</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.4</div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,7 +58,7 @@ let menuState: "closed" | "open" = $state("closed");
 <!-- desktop-only seventh hint (the touch pad is hidden on fine-pointer
      devices; see SeventhPad.svelte) -->
 {#if settings.mode === "chords"}
-	<p class="seventh-hint fixed bottom-4 inset-x-0 text-center text-sm opacity-60 pointer-events-none z-10 text-neutral-50">Hold down Shift to play 7th chords</p>
+	<p class="seventh-hint fixed bottom-4 inset-x-0 text-center text-sm opacity-60 pointer-events-none z-10 text-neutral-50">Shift + click to play 7th chords</p>
 {/if}
 
 


### PR DESCRIPTION
Updates the desktop seventh hint to **"Shift + click to play 7th chords"**. Copy-only change; 186 tests passing, prerender verified.