### PR TITLE
feat: settings menu attribution and close-on-outside-press (v0.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2026-07-12
+
+### Added
+- Attribution in the settings menu: "Made by Kevin Peckham @ Lightning Jar in Philadelphia" linking to lightningjar.com
+- Settings menu closes on a click/tap outside it (hamburger button excluded so its toggle still works)
+
 ## [0.5.4] - 2026-07-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.4
+**Current Version**: 0.5.5
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/HamburgerButton.svelte
+++ b/src/lib/components/HamburgerButton.svelte
@@ -10,6 +10,7 @@ const barClasses = [
 </script>
 
 <button
+	data-hamburger
 	onclick={() => menuState = menuState === "open" ? "closed" : "open"}
 	class="grid grid-cols-1 place-content-start gap-y-2 w-8 h-4 hover:text-accent" aria-label="Toggle menu" aria-expanded={menuState === "open"}>
 

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -112,6 +112,18 @@ import { settings } from "$stores/settings.svelte";
 		</div>
 	{/if}
 
+	<!-- attribution -->
+	<div class="absolute left-8 bottom-8 opacity-60 text-xs">
+		Made by Kevin Peckham @
+		<a
+			href="https://www.lightningjar.com"
+			target="_blank"
+			rel="noopener"
+			class="underline underline-offset-2 hover:text-accent"
+		>Lightning Jar</a>
+		in Philadelphia
+	</div>
+
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.4</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.5</div>
 </div>

--- a/src/lib/components/SettingsPanel.svelte.test.ts
+++ b/src/lib/components/SettingsPanel.svelte.test.ts
@@ -133,4 +133,14 @@ describe("SettingsPanel", () => {
 		render(SettingsPanel);
 		expect(screen.getByText(`v${version}`)).toBeInTheDocument();
 	});
+
+	it("displays the maker attribution with a link to Lightning Jar", () => {
+		render(SettingsPanel);
+		const link = screen.getByRole("link", { name: "Lightning Jar" });
+		expect(link).toHaveAttribute("href", "https://www.lightningjar.com");
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link.parentElement).toHaveTextContent(
+			"Made by Kevin Peckham @ Lightning Jar in Philadelphia",
+		);
+	});
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,20 @@ let { data } = $props();
 
 // state
 let menuState: "closed" | "open" = $state("closed");
+
+// Close the settings menu on a click/tap outside it. The hamburger button
+// is excluded — its own click handler toggles the menu, and closing here
+// first would make that toggle immediately reopen it.
+function closeMenuOnOutsidePress(event: PointerEvent) {
+	if (menuState !== "open") return;
+	const target = event.target as Element | null;
+	if (target?.closest("[data-settings]") || target?.closest("[data-hamburger]"))
+		return;
+	menuState = "closed";
+}
 </script>
+
+<svelte:document onpointerdown={closeMenuOnOutsidePress} />
 
 
 <svelte:head>

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -1,0 +1,78 @@
+// Page-level tests for the settings menu open/close behavior.
+
+import { tick } from "svelte";
+
+import { chordsData } from "$data/chordsData.server";
+
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import Page from "./+page.svelte";
+
+// jsdom has no PointerEvent constructor; the svelte:document listener keys
+// on the event type, so a MouseEvent with the right type works
+function pointerDown(target: Element | Document) {
+	target.dispatchEvent(
+		new MouseEvent("pointerdown", { bubbles: true, cancelable: true }),
+	);
+}
+
+function hamburger(): HTMLElement {
+	return screen.getByRole("button", { name: "Toggle menu" });
+}
+
+describe("+page settings menu", () => {
+	const data = { chords: chordsData };
+
+	it("opens and closes via the hamburger button", async () => {
+		const user = userEvent.setup();
+		render(Page, { data });
+		expect(hamburger()).toHaveAttribute("aria-expanded", "false");
+
+		await user.click(hamburger());
+		expect(hamburger()).toHaveAttribute("aria-expanded", "true");
+
+		await user.click(hamburger());
+		expect(hamburger()).toHaveAttribute("aria-expanded", "false");
+	});
+
+	it("closes when pressing outside the menu", async () => {
+		const user = userEvent.setup();
+		const { container } = render(Page, { data });
+		await user.click(hamburger());
+		expect(hamburger()).toHaveAttribute("aria-expanded", "true");
+
+		const main = container.querySelector("main");
+		if (!main) throw new Error("main not found");
+		pointerDown(main);
+		await tick();
+
+		expect(hamburger()).toHaveAttribute("aria-expanded", "false");
+	});
+
+	it("stays open when pressing inside the menu", async () => {
+		const user = userEvent.setup();
+		const { container } = render(Page, { data });
+		await user.click(hamburger());
+
+		const panel = container.querySelector("[data-settings]");
+		if (!panel) throw new Error("settings panel not found");
+		pointerDown(panel);
+		await tick();
+
+		expect(hamburger()).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("hamburger still toggles closed while open (outside-close does not swallow it)", async () => {
+		const user = userEvent.setup();
+		render(Page, { data });
+		await user.click(hamburger());
+		expect(hamburger()).toHaveAttribute("aria-expanded", "true");
+
+		// user-event fires pointerdown on the button before click; the
+		// outside-close handler must ignore it so the toggle closes the menu
+		// instead of close-then-reopen leaving it open
+		await user.click(hamburger());
+		expect(hamburger()).toHaveAttribute("aria-expanded", "false");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds **"Made by Kevin Peckham @ Lightning Jar in Philadelphia"** at the bottom of the settings menu, with "Lightning Jar" linking to lightningjar.com (new tab).
- The settings menu now **closes on a click/tap outside it**, via a `svelte:document` pointerdown handler. The hamburger button is excluded so its own toggle isn't swallowed by a close-then-reopen race.

## Test plan
- [x] 191 tests passing, including a new page-level suite: hamburger toggle, outside press closes, inside press doesn't, hamburger toggle still closes while open
- [x] svelte-check, biome, build clean
- [ ] Manual: open settings, click the circle — menu closes; tap-outside on phone