### PR TITLE
feat: About page linked from settings (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-12
+
+### Added
+- About page (`/about`), linked from the settings menu: why the tool exists (a handy tool for beginner songwriters), the Quinn Raymond "Q-Ray" inspiration, the basic circle-of-fifths theory behind the instrument, maker credit, and a link to the open-source repository
+
 ## [0.5.5] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.5.5
+**Current Version**: 0.6.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.5.5",
+	"version": "0.6.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -112,6 +112,14 @@ import { settings } from "$stores/settings.svelte";
 		</div>
 	{/if}
 
+	<!-- about link -->
+	<div>
+		<a
+			href="/about"
+			class="text-sm opacity-80 underline underline-offset-2 hover:text-accent hover:opacity-100"
+		>About Fifths &rarr;</a>
+	</div>
+
 	<!-- attribution -->
 	<div class="absolute left-8 bottom-8 opacity-60 text-xs">
 		Made by Kevin Peckham @
@@ -125,5 +133,5 @@ import { settings } from "$stores/settings.svelte";
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.5.5</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.6.0</div>
 </div>

--- a/src/lib/components/SettingsPanel.svelte.test.ts
+++ b/src/lib/components/SettingsPanel.svelte.test.ts
@@ -134,6 +134,12 @@ describe("SettingsPanel", () => {
 		expect(screen.getByText(`v${version}`)).toBeInTheDocument();
 	});
 
+	it("links to the About page", () => {
+		render(SettingsPanel);
+		const about = screen.getByRole("link", { name: "About Fifths →" });
+		expect(about).toHaveAttribute("href", "/about");
+	});
+
 	it("displays the maker attribution with a link to Lightning Jar", () => {
 		render(SettingsPanel);
 		const link = screen.getByRole("link", { name: "Lightning Jar" });

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,0 +1,103 @@
+<!--
+@component
+About page — why Fifths exists, its inspiration, the theory behind it, and
+where the source lives. The app shell locks the viewport (overflow-hidden on
+html/body), so this page provides its own scroll container.
+-->
+
+<svelte:head>
+	<title>About | Fifths</title>
+	<meta
+		content="Why Fifths exists: a playable circle of fifths for beginner songwriters, inspired by Quinn Raymond's Q-Ray, built by Kevin Peckham at Lightning Jar."
+		name="description"
+	/>
+</svelte:head>
+
+<div class="w-full h-screen overflow-y-auto">
+	<header class="page-x-padding py-4 flex items-center justify-between w-full">
+		<a href="/" class="opacity-90 hover:text-accent">&larr; Back to Fifths</a>
+		<h1 class="text-24px text-accent font-700">About</h1>
+	</header>
+
+	<main class="page-x-padding pb-24 text-neutral-50">
+		<div class="max-w-65ch mx-auto grid grid-cols-1 gap-10 pt-8">
+			<!-- why -->
+			<section class="grid gap-3">
+				<h2 class="text-20px font-500 text-accent">Why Fifths exists</h2>
+				<p class="opacity-90 leading-relaxed">
+					Fifths is a playable circle of fifths &mdash; a handy tool for
+					beginner songwriters. Instead of memorizing which chords belong
+					together, you can hear it: chords that sit next to each other on
+					the circle naturally sound good together. Pick a key, wander to
+					its neighbors, and you'll stumble into the progressions behind
+					countless songs &mdash; no theory background required.
+				</p>
+			</section>
+
+			<!-- inspiration -->
+			<section class="grid gap-3">
+				<h2 class="text-20px font-500 text-accent">Inspiration</h2>
+				<p class="opacity-90 leading-relaxed">
+					Fifths is inspired by Quinn Raymond's limited MIDI instrument
+					&ldquo;Q-Ray&rdquo; &mdash; an instrument that embraces
+					constraint, trading range for immediacy so that anyone can pick
+					it up and make music. Fifths borrows that spirit: a single
+					circle, every chord one press away.
+				</p>
+				<p class="opacity-90 leading-relaxed">
+					It was built by
+					<a
+						href="https://www.lightningjar.com"
+						target="_blank"
+						rel="noopener"
+						class="underline underline-offset-2 hover:text-accent"
+					>Kevin Peckham @ Lightning Jar</a>
+					in Philadelphia.
+				</p>
+			</section>
+
+			<!-- theory -->
+			<section class="grid gap-3">
+				<h2 class="text-20px font-500 text-accent">The music theory</h2>
+				<p class="opacity-90 leading-relaxed">
+					The circle of fifths arranges the 12 musical keys so that each
+					step clockwise moves up a perfect fifth (C &rarr; G &rarr; D
+					&hellip;). Keys that are adjacent on the circle share all but
+					one of their notes, which is why moving between neighboring
+					chords sounds smooth and &ldquo;right.&rdquo;
+				</p>
+				<p class="opacity-90 leading-relaxed">
+					In Fifths, the outer ring holds the major chords and the inner
+					ring holds each key's relative minor &mdash; a minor chord built
+					from the same notes as its major partner. For any key you
+					choose, the three chords most songs lean on (the I, IV, and V)
+					sit side by side, with the relative minor (the vi) tucked just
+					inside. That cluster of four wedges is a complete songwriting
+					palette.
+				</p>
+				<p class="opacity-90 leading-relaxed">
+					Holding Shift (or the 7 pad on touch devices) adds a seventh
+					&mdash; one extra note that gives a chord tension and color.
+					Dominant sevenths pull you clockwise around the circle toward
+					the next key; that pull is the engine of the classic
+					ii&ndash;V&ndash;I progression.
+				</p>
+			</section>
+
+			<!-- open source -->
+			<section class="grid gap-3">
+				<h2 class="text-20px font-500 text-accent">Open source</h2>
+				<p class="opacity-90 leading-relaxed">
+					Fifths is open source. The code &mdash; SvelteKit, TypeScript,
+					and the Web Audio API &mdash; lives on GitHub:
+				</p>
+				<a
+					href="https://github.com/kevinpeckham/chord-player/tree/main"
+					target="_blank"
+					rel="noopener"
+					class="underline underline-offset-2 hover:text-accent w-fit"
+				>github.com/kevinpeckham/chord-player</a>
+			</section>
+		</div>
+	</main>
+</div>

--- a/src/routes/about/page.svelte.test.ts
+++ b/src/routes/about/page.svelte.test.ts
@@ -1,0 +1,47 @@
+// Component tests for the About page.
+
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import AboutPage from "./+page.svelte";
+
+describe("About page", () => {
+	it("renders the page heading and a way back to the instrument", () => {
+		render(AboutPage);
+		expect(screen.getByRole("heading", { name: "About" })).toBeInTheDocument();
+		const back = screen.getByRole("link", { name: /Back to Fifths/ });
+		expect(back).toHaveAttribute("href", "/");
+	});
+
+	it("explains who it is for and credits the Q-Ray inspiration", () => {
+		render(AboutPage);
+		expect(screen.getByText(/beginner songwriters/)).toBeInTheDocument();
+		expect(screen.getByText(/Quinn Raymond/)).toBeInTheDocument();
+		expect(screen.getByText(/Q-Ray/)).toBeInTheDocument();
+	});
+
+	it("links the maker credit to Lightning Jar", () => {
+		render(AboutPage);
+		const maker = screen.getByRole("link", {
+			name: "Kevin Peckham @ Lightning Jar",
+		});
+		expect(maker).toHaveAttribute("href", "https://www.lightningjar.com");
+	});
+
+	it("links to the open-source repository", () => {
+		render(AboutPage);
+		const repo = screen.getByRole("link", {
+			name: "github.com/kevinpeckham/chord-player",
+		});
+		expect(repo).toHaveAttribute(
+			"href",
+			"https://github.com/kevinpeckham/chord-player/tree/main",
+		);
+		expect(repo).toHaveAttribute("target", "_blank");
+	});
+
+	it("covers the core music-theory ideas", () => {
+		render(AboutPage);
+		expect(screen.getByText(/perfect fifth/)).toBeInTheDocument();
+		expect(screen.getByText(/relative minor/)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

Adds an **/about** page, linked from the settings menu ("About Fifths →"):

- Why the tool exists — a handy tool for beginner songwriters
- Inspiration: Quinn Raymond's limited MIDI instrument "Q-Ray"
- Built by Kevin Peckham @ Lightning Jar (linked)
- The basic circle-of-fifths theory behind the instrument (fifths, shared notes between neighbors, relative minors, I-IV-V-vi cluster, what sevenths add)
- Link to the open-source repo

The app shell locks the viewport (`overflow-hidden`), so the page provides its own scroll container. Page is prerendered.

## Test plan
- [x] 197 tests passing (new About page suite + settings link test)
- [x] svelte-check, biome, build clean; `about.html` present in prerender output
- [ ] Manual: settings → About Fifths → page scrolls, back link returns to the instrument