### PR TITLE
feat: reverb and progression pad (Phase A, v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-07-12
+
+### Added
+- Reverb: a convolver with a synthesized small-hall impulse response (decaying stereo noise — no audio assets) runs parallel to the dry signal; new "Reverb" wet-mix slider in settings, default 25%
+- Progression pad: every chord played is jotted as a compact symbol (C, Am, C7) onto a pad above the bottom of the screen, with new line / undo / clear controls; content persists in localStorage and the pad stays hidden until the first chord is played
+
 ## [0.6.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.6.0
+**Current Version**: 0.7.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 
@@ -128,12 +128,13 @@ Components are organized in a flat structure:
    - Props passing with `$props()`
    - Computed values with `$derived()`
    - State stores in `/src/lib/stores/`:
-     - `settings.svelte.ts` - Audio settings (oscillator voice selection, chord voicing)
-     - `performance.svelte.ts` - Performance state (active chord display)
-     - `audio.svelte.ts` - Audio engine with singleton AudioContext, reactive state, and volume control
+     - `settings.svelte.ts` - Audio settings (oscillator voice selection, chord voicing, seventh type)
+     - `performance.svelte.ts` - Performance state (active chord display, seventh modifier)
+     - `progression.svelte.ts` - Progression pad (jotted chords, line breaks, localStorage persistence)
+     - `audio.svelte.ts` - Audio engine with singleton AudioContext, reactive state, volume, and convolver reverb (synthesized impulse response)
        - Exports `startChord(frequencies, oscillatorType, pointerId)` for continuous per-pointer playback
        - Exports `stopChordById(pointerId)` and `stopChord()` to end playback
-       - Exports `setMasterVolume(volume)` and the reactive `audioState`
+       - Exports `setMasterVolume(volume)`, `setReverbMix(mix)`, and the reactive `audioState`
 
 4. **Audio Generation**: Uses Web Audio API with oscillator types (sine, triangle, square, sawtooth)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,5 +1,92 @@
 # Proposed Features
 
+## Scoped Roadmap (July 2026)
+
+Eight features, scoped and sequenced. Two pieces of shared infrastructure
+determine the order: a **transport** (BPM + lookahead beat scheduler) that the
+metronome, drum machine, and song playback all need, and a **progression/song
+data format** (sequence of `{chordId, mode, seventh, beats}` entries plus line
+breaks) shared by the tracker, scratch pad, demos, and learn mode. Wedge
+**highlighting** (needed by demos and learn mode) is the trigger for the
+planned Instrument componentization (NotesRing/ChordsRing).
+
+### Phase A — quick wins (no dependencies)
+
+**A1. Reverb** — effort: S
+- Web Audio `ConvolverNode` in the master chain with a synthesized impulse
+  response (exponentially decaying noise buffer — no audio assets needed)
+- Dry/wet mix slider in settings; master chain becomes
+  `chordGain → masterGain → [dry + convolver] → destination`
+- Instant sound-quality win: the raw oscillator voices are dry and harsh
+- Tests: extend the FakeAudioContext stub with `createConvolver`/buffers
+
+**A2. Progression pad** (merges "chords played display/tracker" + "scratch
+pad") — effort: S–M
+- Every chord played is appended to a progression store (id, display name,
+  seventh); shown as a strip/pad below the instrument
+- Controls: line break, delete last, clear/reset
+- Persisted to localStorage (SSR-guarded)
+- This IS the tracker with reset; the scratch pad is the same feature with
+  persistence and line breaks, so build once
+- Forward-compatible: entries use the shared song format, so later a jotted
+  progression can be auto-played (Phase C) or practiced (learn mode)
+
+### Phase B — rhythm infrastructure
+
+**B1. Metronome / click** — effort: S–M
+- Builds the **transport**: BPM setting, play/stop, and a lookahead scheduler
+  (the standard ~25ms `setInterval` scheduling beats ~100ms ahead on the
+  AudioContext clock — required for drift-free timing)
+- Click = short oscillator blip, accented downbeat, time signature 4/4 first
+- Toolbar toggle + BPM control; transport lives in a new store
+
+**B2. Simple drum machine** — effort: M–L (depends on B1)
+- Synthesized kit, no samples: kick (sine pitch-drop), snare (noise burst +
+  tone), hi-hat (filtered noise)
+- 16-step × 3-voice pattern grid UI + a few preset patterns
+- Driven by the transport's scheduler; pattern store persisted to localStorage
+
+### Phase C — song engine + instrument highlighting
+
+**C0. Instrument componentization + highlight state** — effort: M
+(prerequisite for C1/C2; retires the standing fallow suppression)
+- Split the SVG template into NotesRing/ChordsRing; wedges accept a
+  `highlighted` state keyed by chord id
+- Programmatic playback API already exists (`startChord` with a reserved
+  pointer id)
+
+**C1. Auto-play demos** — effort: M (depends on B1 + C0)
+- Song format: shared with the progression pad; demo songs ship as JSON
+- Playback engine walks the song on the transport; wedges light as they play
+- ⚠ Song choice: use public-domain/original progressions (12-bar blues,
+  50s progression, Pachelbel) — named contemporary songs raise rights issues
+- User-jotted progressions from the pad become auto-playable for free
+
+**C2. Wait-for-me playing (learn mode)** — effort: M (depends on C1)
+- Same songs, same highlighting; instead of auto-advance, the engine
+  highlights the next expected chord and listens to Instrument play events,
+  advancing on match (with a "close enough" grace for seventh/voicing)
+- Progress display + restart; the incremental work over C1 is the matcher
+
+### Phase D — real voiced instruments (largest, most open-ended)
+
+**D1. Plucked-string synth voice (Karplus–Strong)** — effort: M
+- Physical-modeling pluck (noise burst into a filtered feedback delay) gives
+  a convincing guitar/harp-like voice with zero audio assets
+- Ships as a fifth entry in the existing voice selector; good test of whether
+  synthesis quality satisfies before investing in samples
+
+**D2. Sampled instruments (true guitar/piano)** — effort: L–XL
+- Requires a multisample set per instrument (licensing/sourcing decision),
+  sample loading + caching strategy (megabytes of assets), pitch-shifting
+  between sampled notes, and per-voicing polyphony management
+- Decision needed before scoping further: source/licensing of sample sets
+  (e.g. open ones like VS Chamber Orchestra/Salamander piano) and how many
+  instruments
+
+### Suggested order
+A1 → A2 → B1 → B2 → C0 → C1 → C2 → D1 → (decide) D2
+
 ## Your Proposed Features
 
 ### 1. Settings Menu

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -25,6 +25,7 @@ import {
 	unlockAudio,
 } from "$stores/audio.svelte";
 import { performance } from "$stores/performance.svelte";
+import { recordChord } from "$stores/progression.svelte";
 import { settings } from "$stores/settings.svelte";
 
 // types
@@ -126,6 +127,18 @@ function chordFrequencies(
 	return withSeventh(base, rootFrequency, mode, settings.seventhType);
 }
 
+// Compact chord symbol for the progression pad ("C", "Am", "C7", "Cmaj7")
+function chordSymbol(
+	datum: Chord,
+	mode: "major" | "minor",
+	seventh: boolean,
+): string {
+	const display = mode === "major" ? datum.majorDisplay : datum.minorDisplay;
+	return seventh
+		? seventhChordName(display, mode, settings.seventhType)
+		: display;
+}
+
 // Chords mode: play the major/minor chord at this wedge position using the
 // selected voicing, adding the seventh when the modifier is active
 function playChordAtIndex(index: number, mode: string, pointerId: number) {
@@ -135,7 +148,16 @@ function playChordAtIndex(index: number, mode: string, pointerId: number) {
 	if (mode !== "major" && mode !== "minor") return;
 
 	const seventh = seventhIsActive(pointerId);
-	setPointerChordName(pointerId, chordDisplayName(datum, mode, seventh));
+
+	// Jot every distinct chord this pointer sounds (new press, slide to a
+	// new wedge, or a seventh change) onto the progression pad
+	const previousName = activePointers.get(pointerId)?.chordName;
+	const chordName = chordDisplayName(datum, mode, seventh);
+	if (chordName !== previousName) {
+		recordChord(chordSymbol(datum, mode, seventh));
+	}
+
+	setPointerChordName(pointerId, chordName);
 	startChord(
 		chordFrequencies(datum, mode, seventh),
 		settings.activeVoice as OscillatorType,

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -18,6 +18,7 @@ import { tick } from "svelte";
 import Instrument from "$components/Instrument.svelte";
 
 import { performance as performanceStore } from "$stores/performance.svelte";
+import { clearProgression, progression } from "$stores/progression.svelte";
 import { settings } from "$stores/settings.svelte";
 
 import { chordsData } from "$data/chordsData.server";
@@ -87,6 +88,7 @@ describe("Instrument", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		vi.clearAllMocks();
+		clearProgression();
 		performanceStore.activeChord = "";
 		performanceStore.seventhHeld = false;
 		settings.activeVoice = "sine";
@@ -357,6 +359,54 @@ describe("Instrument", () => {
 			const { unmount } = render(Instrument, { chords: chordsData });
 			unmount();
 			expect(stopChord).toHaveBeenCalled();
+		});
+	});
+
+	describe("progression jotting", () => {
+		it("records each pressed chord as a compact symbol", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			const amWedge = container.querySelector('[id="chord-button-Am"]');
+			if (!cWedge || !amWedge) throw new Error("wedges not found");
+
+			await pressChord(cWedge, 1);
+			releasePointer(cWedge, 1);
+			await tick();
+			await pressChord(amWedge, 2);
+			releasePointer(amWedge, 2);
+			await tick();
+
+			expect(progression.entries).toEqual([
+				{ kind: "chord", label: "C" },
+				{ kind: "chord", label: "Am" },
+			]);
+		});
+
+		it("records seventh chords with their symbol", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			performanceStore.seventhHeld = true;
+			await tick();
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			if (!cWedge) throw new Error("C wedge not found");
+
+			await pressChord(cWedge, 1);
+
+			expect(progression.entries).toEqual([{ kind: "chord", label: "C7" }]);
+		});
+
+		it("does not re-record when a replay leaves the chord name unchanged", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			if (!cWedge) throw new Error("C wedge not found");
+
+			await pressChord(cWedge, 1);
+			// Changing the seventh type triggers the modifier effect's replay
+			// of held chords; with no seventh active the chord name is
+			// unchanged, so nothing new should be jotted
+			settings.seventhType = "major7";
+			await tick();
+
+			expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
 		});
 	});
 

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -1,0 +1,71 @@
+<!--
+@component
+Progression pad
+- A simple tracker: every chord played is jotted onto the pad
+- Line break / undo / clear controls; content persists in localStorage
+- Hidden until the first chord is played
+-->
+
+<script lang="ts">
+import {
+	addLineBreak,
+	clearProgression,
+	deleteLast,
+	progression,
+} from "$stores/progression.svelte";
+
+// Group flat entries into visual lines at each break
+const lines = $derived.by(() => {
+	const grouped: string[][] = [[]];
+	for (const entry of progression.entries) {
+		if (entry.kind === "break") {
+			grouped.push([]);
+		} else {
+			grouped[grouped.length - 1].push(entry.label);
+		}
+	}
+	return grouped;
+});
+
+const buttonClasses =
+	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60 disabled:opacity-30 disabled:cursor-default";
+</script>
+
+{#if progression.entries.length > 0}
+	<div
+		data-progression-pad
+		class="fixed bottom-12 inset-x-0 z-10 flex justify-center px-4 pointer-events-none"
+	>
+		<div
+			class="pointer-events-auto max-w-full rounded-lg bg-primary/70 backdrop-blur border border-neutral-100/15 px-4 py-3 grid gap-2"
+		>
+			<div
+				class="grid gap-1 max-h-28 overflow-y-auto font-mono text-sm"
+				aria-label="Jotted progression"
+			>
+				{#each lines as line}
+					<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
+						{#each line as label}
+							<span class="opacity-90">{label}</span>
+						{/each}
+					</div>
+				{/each}
+			</div>
+			<div class="flex gap-2">
+				<button type="button" class={buttonClasses} onclick={addLineBreak}>
+					new line
+				</button>
+				<button type="button" class={buttonClasses} onclick={deleteLast}>
+					undo
+				</button>
+				<button
+					type="button"
+					class={buttonClasses}
+					onclick={clearProgression}
+				>
+					clear
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -1,0 +1,63 @@
+// Component tests for the ProgressionPad tracker.
+
+import ProgressionPad from "$components/ProgressionPad.svelte";
+
+import {
+	addLineBreak,
+	clearProgression,
+	progression,
+	recordChord,
+} from "$stores/progression.svelte";
+
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ProgressionPad", () => {
+	beforeEach(() => {
+		clearProgression();
+	});
+
+	it("renders nothing while the pad is empty", () => {
+		const { container } = render(ProgressionPad);
+		expect(container.querySelector("[data-progression-pad]")).toBeNull();
+	});
+
+	it("shows jotted chords in order", () => {
+		recordChord("C");
+		recordChord("Am");
+		render(ProgressionPad);
+		const pad = screen.getByLabelText("Jotted progression");
+		expect(pad).toHaveTextContent("C");
+		expect(pad).toHaveTextContent("Am");
+	});
+
+	it("renders line breaks as separate rows", () => {
+		recordChord("C");
+		addLineBreak();
+		recordChord("G");
+		render(ProgressionPad);
+		const rows = screen
+			.getByLabelText("Jotted progression")
+			.querySelectorAll(":scope > div");
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toHaveTextContent("C");
+		expect(rows[1]).toHaveTextContent("G");
+	});
+
+	it("wires the new line, undo, and clear controls", async () => {
+		const user = userEvent.setup();
+		recordChord("C");
+		recordChord("G");
+		render(ProgressionPad);
+
+		await user.click(screen.getByRole("button", { name: "new line" }));
+		expect(progression.entries.at(-1)).toEqual({ kind: "break" });
+
+		await user.click(screen.getByRole("button", { name: "undo" }));
+		expect(progression.entries.at(-1)).toEqual({ kind: "chord", label: "G" });
+
+		await user.click(screen.getByRole("button", { name: "clear" }));
+		expect(progression.entries).toEqual([]);
+	});
+});

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -3,7 +3,10 @@
 
 import VoicingSelector from "$components/VoicingSelector.svelte";
 
+import { audioState, setReverbMix } from "$stores/audio.svelte";
 import { settings } from "$stores/settings.svelte";
+
+const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 </script>
 
 <div class="grid grid-cols-1 gap-6 page-x-padding pt-4">
@@ -96,6 +99,24 @@ import { settings } from "$stores/settings.svelte";
 		</div>
 	{/if}
 
+	<!-- Reverb -->
+	<div class="flex flex-col gap-2">
+		<label for="reverb-mix" class="text-sm opacity-80">Reverb</label>
+		<div class="flex items-center gap-3">
+			<input
+				id="reverb-mix"
+				type="range"
+				min="0"
+				max="100"
+				value={reverbPercent}
+				oninput={(e) =>
+					setReverbMix(Number.parseInt(e.currentTarget.value, 10) / 100)}
+				class="w-full h-2 cursor-pointer appearance-none rounded-lg bg-gray-200/20 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-accent"
+			/>
+			<span class="text-sm tabular-nums opacity-80 w-10">{reverbPercent}%</span>
+		</div>
+	</div>
+
 	<!-- Octave Selection (only in notes mode) -->
 	{#if settings.mode === "notes"}
 		<div class="flex flex-col gap-2">
@@ -133,5 +154,5 @@ import { settings } from "$stores/settings.svelte";
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.6.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.7.0</div>
 </div>

--- a/src/lib/components/SettingsPanel.svelte.test.ts
+++ b/src/lib/components/SettingsPanel.svelte.test.ts
@@ -3,9 +3,10 @@
 
 import SettingsPanel from "$components/SettingsPanel.svelte";
 
+import { audioState } from "$stores/audio.svelte";
 import { settings } from "$stores/settings.svelte";
 
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { version } from "../../../package.json";
@@ -132,6 +133,16 @@ describe("SettingsPanel", () => {
 	it("displays the current package version", () => {
 		render(SettingsPanel);
 		expect(screen.getByText(`v${version}`)).toBeInTheDocument();
+	});
+
+	it("adjusts the reverb mix from the slider", async () => {
+		audioState.reverbMix = 0.25;
+		render(SettingsPanel);
+		const slider = screen.getByLabelText("Reverb") as HTMLInputElement;
+		expect(slider).toHaveValue("25");
+
+		await fireEvent.input(slider, { target: { value: "60" } });
+		expect(audioState.reverbMix).toBe(0.6);
 	});
 
 	it("links to the About page", () => {

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -40,6 +40,27 @@ class FakeOscillatorNode {
 	onended: (() => void) | null = null;
 }
 
+class FakeConvolverNode {
+	buffer: unknown = null;
+	connect = vi.fn();
+	disconnect = vi.fn();
+}
+
+class FakeAudioBuffer {
+	numberOfChannels = 2;
+	channels: Float32Array[];
+	constructor(channels: number, length: number) {
+		this.numberOfChannels = channels;
+		this.channels = Array.from(
+			{ length: channels },
+			() => new Float32Array(length),
+		);
+	}
+	getChannelData(channel: number) {
+		return this.channels[channel];
+	}
+}
+
 class FakeAudioContext {
 	static instances: FakeAudioContext[] = [];
 	// Allows a test to make the next context start out suspended.
@@ -47,10 +68,13 @@ class FakeAudioContext {
 
 	state: AudioContextState = FakeAudioContext.initialState;
 	currentTime = 0;
+	// Small so impulse-response generation stays fast in tests
+	sampleRate = 100;
 	destination = { connect: vi.fn(), disconnect: vi.fn() };
 	onstatechange: (() => void) | null = null;
 	createdGains: FakeGainNode[] = [];
 	createdOscillators: FakeOscillatorNode[] = [];
+	createdConvolvers: FakeConvolverNode[] = [];
 
 	constructor() {
 		FakeAudioContext.instances.push(this);
@@ -66,6 +90,16 @@ class FakeAudioContext {
 		const osc = new FakeOscillatorNode();
 		this.createdOscillators.push(osc);
 		return osc;
+	}
+
+	createConvolver() {
+		const convolver = new FakeConvolverNode();
+		this.createdConvolvers.push(convolver);
+		return convolver;
+	}
+
+	createBuffer(channels: number, length: number, _sampleRate: number) {
+		return new FakeAudioBuffer(channels, length);
 	}
 
 	resume = vi.fn(async () => {
@@ -131,6 +165,32 @@ describe("audio store", () => {
 			const masterGain = ctx.createdGains[0];
 			expect(masterGain.connect).toHaveBeenCalledWith(ctx.destination);
 			expect(masterGain.gain.value).toBe(audio.audioState.masterVolume);
+		});
+
+		it("wires a parallel convolver reverb path with an impulse response", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			const ctx = FakeAudioContext.instances[0];
+
+			expect(ctx.createdConvolvers).toHaveLength(1);
+			const convolver = ctx.createdConvolvers[0];
+			const masterGain = ctx.createdGains[0];
+			const wetGain = ctx.createdGains[1];
+
+			// masterGain feeds both the destination (dry) and the convolver
+			expect(masterGain.connect).toHaveBeenCalledWith(ctx.destination);
+			expect(masterGain.connect).toHaveBeenCalledWith(convolver);
+			expect(convolver.connect).toHaveBeenCalledWith(wetGain);
+			expect(wetGain.connect).toHaveBeenCalledWith(ctx.destination);
+			expect(wetGain.gain.value).toBe(audio.audioState.reverbMix);
+
+			// The impulse response is a stereo decaying-noise buffer
+			const buffer = convolver.buffer as FakeAudioBuffer;
+			expect(buffer.numberOfChannels).toBe(2);
+			const data = buffer.getChannelData(0);
+			expect(data.length).toBeGreaterThan(0);
+			// Decays to silence at the tail
+			expect(Math.abs(data[data.length - 1])).toBeLessThan(0.01);
 		});
 
 		it("resumes a suspended context before playing", async () => {
@@ -239,8 +299,8 @@ describe("audio store", () => {
 			const audio = await freshStore();
 			await audio.startChord(C_MAJOR, "sine", 1);
 			const ctx = FakeAudioContext.instances[0];
-			// gains: [0] master, [1] chordGain, then per-note gains
-			const chordGain = ctx.createdGains[1];
+			// gains: [0] master, [1] reverb wet, [2] chordGain, then per-note
+			const chordGain = ctx.createdGains[2];
 
 			audio.stopChordById(1);
 
@@ -258,8 +318,8 @@ describe("audio store", () => {
 			const audio = await freshStore();
 			await audio.startChord(C_MAJOR, "sine", 1);
 			const ctx = FakeAudioContext.instances[0];
-			const chordGain = ctx.createdGains[1];
-			const noteGains = ctx.createdGains.slice(2);
+			const chordGain = ctx.createdGains[2];
+			const noteGains = ctx.createdGains.slice(3);
 
 			audio.stopChordById(1);
 			// Cleanup has not run yet.
@@ -410,6 +470,36 @@ describe("audio store", () => {
 			const audio = await freshStore();
 			expect(() => audio.setMasterVolume(0.3)).not.toThrow();
 			expect(audio.audioState.masterVolume).toBe(0.3);
+			expect(FakeAudioContext.instances).toHaveLength(0);
+		});
+	});
+
+	describe("setReverbMix", () => {
+		it("clamps the mix to [0, 1] and updates state", async () => {
+			const audio = await freshStore();
+			audio.setReverbMix(1.5);
+			expect(audio.audioState.reverbMix).toBe(1);
+			audio.setReverbMix(-0.5);
+			expect(audio.audioState.reverbMix).toBe(0);
+		});
+
+		it("applies the mix to the reverb wet gain once initialized", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			const ctx = FakeAudioContext.instances[0];
+			const wetGain = ctx.createdGains[1];
+
+			audio.setReverbMix(0.6);
+			expect(wetGain.gain.setValueAtTime).toHaveBeenCalledWith(
+				0.6,
+				ctx.currentTime,
+			);
+		});
+
+		it("works before initialization without touching a gain node", async () => {
+			const audio = await freshStore();
+			expect(() => audio.setReverbMix(0.4)).not.toThrow();
+			expect(audio.audioState.reverbMix).toBe(0.4);
 			expect(FakeAudioContext.instances).toHaveLength(0);
 		});
 	});

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -1,6 +1,7 @@
 // Audio engine store - manages AudioContext and sound generation
 let audioContext: AudioContext | null = null;
 let masterGainNode: GainNode | null = null;
+let reverbWetGain: GainNode | null = null;
 
 // Active oscillators tracking for cleanup
 const activeOscillators = new Set<OscillatorNode>();
@@ -21,9 +22,28 @@ export const audioState = $state({
 	isInitialized: false,
 	isPlaying: false,
 	masterVolume: 0.8,
+	reverbMix: 0.25,
 	activeNoteCount: 0,
 	contextState: "suspended" as AudioContextState,
 });
+
+// Synthesize a reverb impulse response: exponentially decaying stereo noise.
+// No audio assets required, and the tail length/decay give a small-hall feel.
+function createImpulseResponse(
+	ctx: AudioContext,
+	duration = 2.5,
+	decay = 3,
+): AudioBuffer {
+	const length = Math.max(1, Math.floor(ctx.sampleRate * duration));
+	const buffer = ctx.createBuffer(2, length, ctx.sampleRate);
+	for (let channel = 0; channel < buffer.numberOfChannels; channel++) {
+		const data = buffer.getChannelData(channel);
+		for (let i = 0; i < length; i++) {
+			data[i] = (Math.random() * 2 - 1) * (1 - i / length) ** decay;
+		}
+	}
+	return buffer;
+}
 
 // Initialize audio context lazily (on first user interaction)
 function initializeAudio(): AudioContext {
@@ -36,8 +56,20 @@ function initializeAudio(): AudioContext {
 
 		// Create master gain for volume control
 		masterGainNode = audioContext.createGain();
-		masterGainNode.connect(audioContext.destination);
 		masterGainNode.gain.value = audioState.masterVolume;
+
+		// Master chain: dry signal passes straight through; a parallel
+		// convolver adds the reverb tail, blended by the wet gain.
+		//   masterGain ─┬────────────────────────→ destination
+		//               └→ convolver → wetGain ──→ destination
+		masterGainNode.connect(audioContext.destination);
+		const convolver = audioContext.createConvolver();
+		convolver.buffer = createImpulseResponse(audioContext);
+		reverbWetGain = audioContext.createGain();
+		reverbWetGain.gain.value = audioState.reverbMix;
+		masterGainNode.connect(convolver);
+		convolver.connect(reverbWetGain);
+		reverbWetGain.connect(audioContext.destination);
 
 		// Update reactive state
 		audioState.isInitialized = true;
@@ -88,6 +120,17 @@ export function unlockAudio(): void {
 export function setMasterVolume(volume: number): void {
 	audioState.masterVolume = Math.max(0, Math.min(1, volume));
 	updateMasterGainVolume();
+}
+
+// Reactive reverb wet-mix control (0-1); 0 is fully dry
+export function setReverbMix(mix: number): void {
+	audioState.reverbMix = Math.max(0, Math.min(1, mix));
+	if (reverbWetGain && audioContext) {
+		reverbWetGain.gain.setValueAtTime(
+			audioState.reverbMix,
+			audioContext.currentTime,
+		);
+	}
 }
 
 // Suspend audio while the page is hidden, resume when it returns

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -1,0 +1,81 @@
+// Tests for the progression pad store (jotting + localStorage persistence).
+
+import {
+	addLineBreak,
+	clearProgression,
+	deleteLast,
+	progression,
+	recordChord,
+} from "$stores/progression.svelte";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+const STORAGE_KEY = "fifths-progression";
+
+function stored() {
+	return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+}
+
+describe("progression store", () => {
+	beforeEach(() => {
+		clearProgression();
+		localStorage.clear();
+	});
+
+	it("records chords in order", () => {
+		recordChord("C");
+		recordChord("Am");
+		recordChord("F7");
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C" },
+			{ kind: "chord", label: "Am" },
+			{ kind: "chord", label: "F7" },
+		]);
+	});
+
+	it("adds line breaks between chords but never leading or doubled", () => {
+		addLineBreak(); // leading — ignored
+		expect(progression.entries).toEqual([]);
+
+		recordChord("C");
+		addLineBreak();
+		addLineBreak(); // doubled — ignored
+		recordChord("G");
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C" },
+			{ kind: "break" },
+			{ kind: "chord", label: "G" },
+		]);
+	});
+
+	it("deletes the most recent entry", () => {
+		recordChord("C");
+		recordChord("G");
+		deleteLast();
+		expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
+		deleteLast();
+		deleteLast(); // empty — no throw
+		expect(progression.entries).toEqual([]);
+	});
+
+	it("clears the pad", () => {
+		recordChord("C");
+		addLineBreak();
+		recordChord("G");
+		clearProgression();
+		expect(progression.entries).toEqual([]);
+		expect(stored()).toEqual([]);
+	});
+
+	it("persists every mutation to localStorage", () => {
+		recordChord("C");
+		expect(stored()).toEqual([{ kind: "chord", label: "C" }]);
+		addLineBreak();
+		recordChord("G");
+		deleteLast();
+		expect(stored()).toEqual([
+			{ kind: "chord", label: "C" },
+			{ kind: "break" },
+		]);
+	});
+});

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -1,0 +1,67 @@
+// Progression pad store - captures played chords as a jotted progression,
+// persisted to localStorage so a work-in-progress survives reloads.
+
+export type ProgressionEntry =
+	| { kind: "chord"; label: string }
+	| { kind: "break" };
+
+const STORAGE_KEY = "fifths-progression";
+
+// Guarded for SSR/prerender, where localStorage does not exist
+function loadEntries(): ProgressionEntry[] {
+	if (typeof localStorage === "undefined") return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter(
+			(entry): entry is ProgressionEntry =>
+				entry?.kind === "break" ||
+				(entry?.kind === "chord" && typeof entry.label === "string"),
+		);
+	} catch {
+		return [];
+	}
+}
+
+function persist(): void {
+	if (typeof localStorage === "undefined") return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(progression.entries));
+	} catch {
+		// Storage may be full or blocked (private browsing) — jotting still
+		// works for the session, it just won't survive a reload
+	}
+}
+
+export const progression = $state({
+	entries: loadEntries(),
+});
+
+// Append a played chord (called by the Instrument on each distinct chord)
+export function recordChord(label: string): void {
+	progression.entries.push({ kind: "chord", label });
+	persist();
+}
+
+// Start a new line in the jotted progression
+export function addLineBreak(): void {
+	// No leading or doubled breaks — they would render as empty lines
+	const last = progression.entries.at(-1);
+	if (!last || last.kind === "break") return;
+	progression.entries.push({ kind: "break" });
+	persist();
+}
+
+// Remove the most recent entry (chord or break)
+export function deleteLast(): void {
+	progression.entries.pop();
+	persist();
+}
+
+// Wipe the pad
+export function clearProgression(): void {
+	progression.entries.length = 0;
+	persist();
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 
 import HamburgerButton from "$components/HamburgerButton.svelte";
 import Instrument from "$components/Instrument.svelte";
+import ProgressionPad from "$components/ProgressionPad.svelte";
 import SettingsPanel from "$components/SettingsPanel.svelte";
 import SeventhPad from "$components/SeventhPad.svelte";
 import VolumeControl from "$components/VolumeControl.svelte";
@@ -67,6 +68,11 @@ function closeMenuOnOutsidePress(event: PointerEvent) {
 	</div>
 
 </main>
+
+<!-- progression pad (chords mode only) -->
+{#if settings.mode === "chords"}
+	<ProgressionPad />
+{/if}
 
 <!-- desktop-only seventh hint (the touch pad is hidden on fine-pointer
      devices; see SeventhPad.svelte) -->


### PR DESCRIPTION
## Summary

First two features from the scoped roadmap (docs/FEATURES.md):

**A1 — Reverb**
- `ConvolverNode` with a *synthesized* small-hall impulse response (exponentially decaying stereo noise, generated at init — zero audio assets)
- Runs parallel to the dry signal; new **Reverb** wet-mix slider in settings (default 25%)

**A2 — Progression pad** (the "chords played tracker" and "scratch pad" built as one feature)
- Every distinct chord played is jotted as a compact symbol (C, Am, C7) onto a floating pad
- **new line / undo / clear** controls; persists to localStorage; hidden until the first chord plays
- Entries use the shared song format, so Phase C playback/learn modes can consume jotted progressions

Also includes the scoped roadmap doc itself.

## Test plan
- [x] 214 tests passing (+17: reverb chain wiring, mix clamping, store persistence rules, pad UI, Instrument jotting incl. no-duplicate-on-replay)
- [x] svelte-check, biome, build clean
- [ ] Manual: play chords → pad appears and jots; reverb slider audibly changes the tail; reload → progression survives