### PR TITLE
feat: progression pad controls and reverb shortcut (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-07-12
+
+### Added
+- Progression pad controls: pause/resume button (paused = chords are not jotted), an X to dismiss the pad, and a "Show progression pad" toggle in settings to bring it back
+- Keyboard shortcut: press R to toggle reverb on/off (restores the last audible mix; ignored while typing in a form control)
+
+### Changed
+- The progression pad moved from a floating strip at the bottom of the screen to sit above the volume control
+
 ## [0.7.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.7.0
+**Current Version**: 0.8.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,6 +31,21 @@ pad") — effort: S–M
 - Forward-compatible: entries use the shared song format, so later a jotted
   progression can be auto-played (Phase C) or practiced (learn mode)
 
+### Audio effects backlog (post-Phase-A additions)
+
+Both follow the master-chain pattern established by the reverb (parallel or
+insert node + a settings slider), so each is a small standalone ship:
+
+**Distortion** — effort: S
+- `WaveShaperNode` with a soft-clipping curve (e.g. tanh-based), amount
+  control in settings; insert before the master gain
+- Pairs naturally with the sawtooth/square voices
+
+**Delay** — effort: S
+- `DelayNode` + feedback gain loop in parallel with the dry signal
+  (like the reverb send); time + feedback controls in settings
+- Later: sync delay time to the transport's BPM once Phase B lands
+
 ### Phase B — rhythm infrastructure
 
 **B1. Metronome / click** — effort: S–M

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -22,6 +22,7 @@ import {
 	startChord,
 	stopChord,
 	stopChordById,
+	toggleReverb,
 	unlockAudio,
 } from "$stores/audio.svelte";
 import { performance } from "$stores/performance.svelte";
@@ -315,9 +316,19 @@ function handleGlobalPointerUp(event: PointerEvent) {
 	releasePointer(event.pointerId);
 }
 
-// Shift is the desktop seventh modifier: held = sevenths, released = triads
+// True when the key press happened while typing in a form control
+function isTypingTarget(event: KeyboardEvent): boolean {
+	const target = event.target as HTMLElement | null;
+	return !!target && ["INPUT", "SELECT", "TEXTAREA"].includes(target.tagName);
+}
+
+// Shift is the desktop seventh modifier: held = sevenths, released = triads.
+// R toggles reverb on/off.
 function onWindowKeyDown(event: KeyboardEvent) {
 	if (event.key === "Shift") performance.seventhHeld = true;
+	if ((event.key === "r" || event.key === "R") && !isTypingTarget(event)) {
+		toggleReverb();
+	}
 }
 function onWindowKeyUp(event: KeyboardEvent) {
 	if (event.key === "Shift") performance.seventhHeld = false;

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -38,6 +38,7 @@ vi.mock("$stores/audio.svelte", () => ({
 	startChord: vi.fn(),
 	stopChord: vi.fn(),
 	stopChordById: vi.fn(),
+	toggleReverb: vi.fn(),
 	unlockAudio: vi.fn(),
 }));
 
@@ -45,6 +46,7 @@ import {
 	startChord,
 	stopChord,
 	stopChordById,
+	toggleReverb,
 	unlockAudio,
 } from "$stores/audio.svelte";
 
@@ -359,6 +361,33 @@ describe("Instrument", () => {
 			const { unmount } = render(Instrument, { chords: chordsData });
 			unmount();
 			expect(stopChord).toHaveBeenCalled();
+		});
+	});
+
+	describe("keyboard shortcuts", () => {
+		it("toggles reverb with the R key", async () => {
+			render(Instrument, { chords: chordsData });
+			window.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "r", bubbles: true }),
+			);
+			expect(toggleReverb).toHaveBeenCalledTimes(1);
+
+			window.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "R", bubbles: true }),
+			);
+			expect(toggleReverb).toHaveBeenCalledTimes(2);
+		});
+
+		it("ignores R typed into a form control", async () => {
+			render(Instrument, { chords: chordsData });
+			const input = document.createElement("input");
+			document.body.appendChild(input);
+
+			input.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "r", bubbles: true }),
+			);
+			expect(toggleReverb).not.toHaveBeenCalled();
+			input.remove();
 		});
 	});
 

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -2,7 +2,8 @@
 @component
 Progression pad
 - A simple tracker: every chord played is jotted onto the pad
-- Line break / undo / clear controls; content persists in localStorage
+- Line break / undo / clear controls; pause stops jotting; the X hides the
+  pad (re-enable from settings); content persists in localStorage
 - Hidden until the first chord is played
 -->
 
@@ -12,7 +13,9 @@ import {
 	clearProgression,
 	deleteLast,
 	progression,
+	togglePaused,
 } from "$stores/progression.svelte";
+import { settings } from "$stores/settings.svelte";
 
 // Group flat entries into visual lines at each break
 const lines = $derived.by(() => {
@@ -27,45 +30,60 @@ const lines = $derived.by(() => {
 	return grouped;
 });
 
+function dismiss() {
+	settings.showProgressionPad = false;
+}
+
 const buttonClasses =
-	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60 disabled:opacity-30 disabled:cursor-default";
+	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60";
 </script>
 
 {#if progression.entries.length > 0}
 	<div
 		data-progression-pad
-		class="fixed bottom-12 inset-x-0 z-10 flex justify-center px-4 pointer-events-none"
+		class="relative w-full max-w-500px rounded-lg bg-primary/70 border border-neutral-100/15 px-4 py-3 pr-10 grid gap-2"
 	>
+		<button
+			type="button"
+			aria-label="Hide progression pad"
+			title="Hide progression pad (re-enable in settings)"
+			class="absolute top-2 right-2 w-6 h-6 grid place-items-center rounded opacity-60 hover:opacity-100 hover:text-accent"
+			onclick={dismiss}
+		>&times;</button>
+
 		<div
-			class="pointer-events-auto max-w-full rounded-lg bg-primary/70 backdrop-blur border border-neutral-100/15 px-4 py-3 grid gap-2"
+			class="grid gap-1 max-h-28 overflow-y-auto font-mono text-sm"
+			aria-label="Jotted progression"
 		>
-			<div
-				class="grid gap-1 max-h-28 overflow-y-auto font-mono text-sm"
-				aria-label="Jotted progression"
+			{#each lines as line}
+				<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
+					{#each line as label}
+						<span class="opacity-90">{label}</span>
+					{/each}
+				</div>
+			{/each}
+		</div>
+		<div class="flex gap-2">
+			<button
+				type="button"
+				class="{buttonClasses} {progression.paused ? 'text-accent border-accent/60' : ''}"
+				aria-pressed={progression.paused}
+				title={progression.paused
+					? "Resume jotting chords"
+					: "Pause jotting chords"}
+				onclick={togglePaused}
 			>
-				{#each lines as line}
-					<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
-						{#each line as label}
-							<span class="opacity-90">{label}</span>
-						{/each}
-					</div>
-				{/each}
-			</div>
-			<div class="flex gap-2">
-				<button type="button" class={buttonClasses} onclick={addLineBreak}>
-					new line
-				</button>
-				<button type="button" class={buttonClasses} onclick={deleteLast}>
-					undo
-				</button>
-				<button
-					type="button"
-					class={buttonClasses}
-					onclick={clearProgression}
-				>
-					clear
-				</button>
-			</div>
+				{progression.paused ? "resume" : "pause"}
+			</button>
+			<button type="button" class={buttonClasses} onclick={addLineBreak}>
+				new line
+			</button>
+			<button type="button" class={buttonClasses} onclick={deleteLast}>
+				undo
+			</button>
+			<button type="button" class={buttonClasses} onclick={clearProgression}>
+				clear
+			</button>
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -8,6 +8,7 @@ import {
 	progression,
 	recordChord,
 } from "$stores/progression.svelte";
+import { settings } from "$stores/settings.svelte";
 
 import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
@@ -16,6 +17,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 describe("ProgressionPad", () => {
 	beforeEach(() => {
 		clearProgression();
+		progression.paused = false;
+		settings.showProgressionPad = true;
 	});
 
 	it("renders nothing while the pad is empty", () => {
@@ -43,6 +46,39 @@ describe("ProgressionPad", () => {
 		expect(rows).toHaveLength(2);
 		expect(rows[0]).toHaveTextContent("C");
 		expect(rows[1]).toHaveTextContent("G");
+	});
+
+	it("toggles jotting with the pause button", async () => {
+		const user = userEvent.setup();
+		recordChord("C");
+		render(ProgressionPad);
+
+		const pause = screen.getByRole("button", { name: "pause" });
+		expect(pause).toHaveAttribute("aria-pressed", "false");
+		await user.click(pause);
+		expect(progression.paused).toBe(true);
+
+		// While paused, plays are not jotted
+		recordChord("G");
+		expect(progression.entries).toHaveLength(1);
+
+		const resume = screen.getByRole("button", { name: "resume" });
+		expect(resume).toHaveAttribute("aria-pressed", "true");
+		await user.click(resume);
+		expect(progression.paused).toBe(false);
+	});
+
+	it("dismisses the pad via the X (re-enabled from settings)", async () => {
+		const user = userEvent.setup();
+		recordChord("C");
+		render(ProgressionPad);
+
+		await user.click(
+			screen.getByRole("button", { name: "Hide progression pad" }),
+		);
+		expect(settings.showProgressionPad).toBe(false);
+		// Entries are kept — dismissing hides, it does not clear
+		expect(progression.entries).toHaveLength(1);
 	});
 
 	it("wires the new line, undo, and clear controls", async () => {

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -115,7 +115,21 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 			/>
 			<span class="text-sm tabular-nums opacity-80 w-10">{reverbPercent}%</span>
 		</div>
+		<p class="text-xs opacity-60">Press R to toggle reverb on and off.</p>
 	</div>
+
+	<!-- Progression Pad visibility (only in chords mode) -->
+	{#if settings.mode === "chords"}
+		<div class="flex items-center gap-3">
+			<input
+				id="progression-pad-toggle"
+				type="checkbox"
+				bind:checked={settings.showProgressionPad}
+				class="w-4 h-4 accent-accent cursor-pointer"
+			/>
+			<label for="progression-pad-toggle" class="text-sm opacity-80 cursor-pointer">Show progression pad</label>
+		</div>
+	{/if}
 
 	<!-- Octave Selection (only in notes mode) -->
 	{#if settings.mode === "notes"}
@@ -154,5 +168,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.7.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.8.0</div>
 </div>

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -503,4 +503,24 @@ describe("audio store", () => {
 			expect(FakeAudioContext.instances).toHaveLength(0);
 		});
 	});
+
+	describe("toggleReverb", () => {
+		it("turns reverb off and restores the last audible mix on the next toggle", async () => {
+			const audio = await freshStore();
+			audio.setReverbMix(0.6);
+
+			audio.toggleReverb();
+			expect(audio.audioState.reverbMix).toBe(0);
+
+			audio.toggleReverb();
+			expect(audio.audioState.reverbMix).toBe(0.6);
+		});
+
+		it("restores the default mix when toggled on without a prior setting", async () => {
+			const audio = await freshStore();
+			audio.setReverbMix(0);
+			audio.toggleReverb();
+			expect(audio.audioState.reverbMix).toBe(0.25);
+		});
+	});
 });

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -122,15 +122,26 @@ export function setMasterVolume(volume: number): void {
 	updateMasterGainVolume();
 }
 
+// Remembers the last audible mix so toggling reverb back on restores it
+let lastAudibleReverbMix = 0.25;
+
 // Reactive reverb wet-mix control (0-1); 0 is fully dry
 export function setReverbMix(mix: number): void {
 	audioState.reverbMix = Math.max(0, Math.min(1, mix));
+	if (audioState.reverbMix > 0) {
+		lastAudibleReverbMix = audioState.reverbMix;
+	}
 	if (reverbWetGain && audioContext) {
 		reverbWetGain.gain.setValueAtTime(
 			audioState.reverbMix,
 			audioContext.currentTime,
 		);
 	}
+}
+
+// On/off toggle (keyboard shortcut): off = fully dry, on = last audible mix
+export function toggleReverb(): void {
+	setReverbMix(audioState.reverbMix > 0 ? 0 : lastAudibleReverbMix);
 }
 
 // Suspend audio while the page is hidden, resume when it returns

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	deleteLast,
 	progression,
 	recordChord,
+	togglePaused,
 } from "$stores/progression.svelte";
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -19,7 +20,23 @@ function stored() {
 describe("progression store", () => {
 	beforeEach(() => {
 		clearProgression();
+		progression.paused = false;
 		localStorage.clear();
+	});
+
+	it("does not record while paused, and resumes recording after", () => {
+		recordChord("C");
+		togglePaused();
+		expect(progression.paused).toBe(true);
+		recordChord("G");
+		expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
+
+		togglePaused();
+		recordChord("Am");
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C" },
+			{ kind: "chord", label: "Am" },
+		]);
 	});
 
 	it("records chords in order", () => {

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -37,12 +37,20 @@ function persist(): void {
 
 export const progression = $state({
 	entries: loadEntries(),
+	// While paused, played chords are not jotted (session-only, not persisted)
+	paused: false,
 });
 
 // Append a played chord (called by the Instrument on each distinct chord)
 export function recordChord(label: string): void {
+	if (progression.paused) return;
 	progression.entries.push({ kind: "chord", label });
 	persist();
+}
+
+// Pause/resume jotting
+export function togglePaused(): void {
+	progression.paused = !progression.paused;
 }
 
 // Start a new line in the jotted progression

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -25,4 +25,5 @@ export const settings = $state({
 		| "A#"
 		| "B",
 	keyCenterPosition: "bottom" as "top" | "bottom",
+	showProgressionPad: true,
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,6 +50,11 @@ function closeMenuOnOutsidePress(event: PointerEvent) {
 
 <main class="relative grid grid-cols-1 gap-y-12 place-items-center page-x-padding pb-36 text-neutral-50 max-w-full max-h-full z-0">
 
+		<!-- progression pad (chords mode only, toggleable in settings) -->
+		{#if settings.mode === "chords" && settings.showProgressionPad}
+			<ProgressionPad />
+		{/if}
+
 		<!-- toolbar -->
 		<div data-toolbar class="flex items-center gap-6">
 			<!-- volume control -->
@@ -68,11 +73,6 @@ function closeMenuOnOutsidePress(event: PointerEvent) {
 	</div>
 
 </main>
-
-<!-- progression pad (chords mode only) -->
-{#if settings.mode === "chords"}
-	<ProgressionPad />
-{/if}
 
 <!-- desktop-only seventh hint (the touch pad is hidden on fine-pointer
      devices; see SeventhPad.svelte) -->

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -2,11 +2,14 @@
 
 import { tick } from "svelte";
 
+import { clearProgression, recordChord } from "$stores/progression.svelte";
+import { settings } from "$stores/settings.svelte";
+
 import { chordsData } from "$data/chordsData.server";
 
 import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import Page from "./+page.svelte";
 
 // jsdom has no PointerEvent constructor; the svelte:document listener keys
@@ -20,6 +23,36 @@ function pointerDown(target: Element | Document) {
 function hamburger(): HTMLElement {
 	return screen.getByRole("button", { name: "Toggle menu" });
 }
+
+describe("+page progression pad visibility", () => {
+	const data = { chords: chordsData };
+
+	beforeEach(() => {
+		clearProgression();
+		settings.mode = "chords";
+		settings.showProgressionPad = true;
+	});
+
+	it("shows the pad above the toolbar when enabled and there are entries", () => {
+		recordChord("C");
+		const { container } = render(Page, { data });
+		const pad = container.querySelector("[data-progression-pad]");
+		expect(pad).not.toBeNull();
+		// The pad renders before (above) the toolbar in document order
+		const toolbar = container.querySelector("[data-toolbar]");
+		if (!pad || !toolbar) throw new Error("pad or toolbar missing");
+		expect(
+			pad.compareDocumentPosition(toolbar) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("hides the pad when the setting is off", () => {
+		recordChord("C");
+		settings.showProgressionPad = false;
+		const { container } = render(Page, { data });
+		expect(container.querySelector("[data-progression-pad]")).toBeNull();
+	});
+});
 
 describe("+page settings menu", () => {
 	const data = { chords: chordsData };


### PR DESCRIPTION
## Summary

**Progression pad**
- **pause/resume** button — while paused, played chords are not jotted
- **X** dismisses the pad; a new **"Show progression pad"** checkbox in settings brings it back (entries are kept — dismiss hides, it doesn't clear)
- Pad moved from the floating bottom strip to sit **above the volume control**

**Reverb**
- Press **R** to toggle reverb off/on — toggling on restores the last audible mix; ignored while typing in a form control; hint added under the reverb slider

Also carries the distortion/delay roadmap additions to docs/FEATURES.md.

## Test plan
- [x] 223 tests passing (+9: pause semantics, dismiss, settings gate + pad-above-toolbar order, reverb toggle/restore, R shortcut incl. form-control guard)
- [x] svelte-check, biome, build clean
- [ ] Manual: pause → play → nothing jotted; X hides; settings checkbox restores; R toggles the tail audibly