### PR TITLE
feat: MIDI for the progression pad — playback and .mid export (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-12
+
+### Added
+- MIDI for the progression pad:
+  - Jotted chords now record their MIDI note numbers (exact conversion from the app's equal-tempered frequencies)
+  - **play/stop** on the pad plays the progression back through the app synth, highlighting each chord as it sounds; playback cannot re-jot itself
+  - **export midi** downloads the progression as a standard `.mid` file (format 0, hand-rolled writer, no dependencies) that opens in any DAW — each chord is a quarter note at 120 BPM, line breaks become rests
+- Progression storage bumped to schema v2 (entries carry notes); pre-MIDI jottings are not migrated
+
 ## [0.8.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.8.0
+**Current Version**: 0.9.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,6 +46,18 @@ insert node + a settings slider), so each is a small standalone ship:
   (like the reverb send); time + feedback controls in settings
 - Later: sync delay time to the transport's BPM once Phase B lands
 
+### MIDI (M1–M3 shipped in v0.9.0; M4 deferred)
+
+- ✅ M1: pad entries record MIDI note numbers (exact conversion from the
+  equal-tempered frequencies at jot time; storage schema v2)
+- ✅ M2: pad playback through the app synth (reserved pointer ID, cannot
+  re-jot itself; uniform 120 BPM steps until the transport lands)
+- ✅ M3: .mid export — hand-rolled SMF format-0 writer, zero dependencies;
+  each chord one quarter note, line breaks become rests
+- ⏳ M4: live Web MIDI out to devices/DAWs — bigger scope (port selection,
+  permissions, scheduling) and no Safari support; aligns with the older
+  "MIDI Controller/Slave Mode" items below
+
 ### Phase B — rhythm infrastructure
 
 **B1. Metronome / click** — effort: S–M

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -43,6 +43,7 @@ import { untrack } from "svelte";
 // import utils
 import { textCoords, wedgePath } from "$utils/circleGeometry";
 import { processChordEnharmonics } from "$utils/enharmonics";
+import { frequenciesToMidi } from "$utils/midi";
 import { CHROMATIC_NOTES, getNoteForPosition } from "$utils/noteHelpers";
 import { seventhChordName, withSeventh } from "$utils/sevenths";
 
@@ -149,21 +150,21 @@ function playChordAtIndex(index: number, mode: string, pointerId: number) {
 	if (mode !== "major" && mode !== "minor") return;
 
 	const seventh = seventhIsActive(pointerId);
+	const frequencies = chordFrequencies(datum, mode, seventh);
 
 	// Jot every distinct chord this pointer sounds (new press, slide to a
 	// new wedge, or a seventh change) onto the progression pad
 	const previousName = activePointers.get(pointerId)?.chordName;
 	const chordName = chordDisplayName(datum, mode, seventh);
 	if (chordName !== previousName) {
-		recordChord(chordSymbol(datum, mode, seventh));
+		recordChord(
+			chordSymbol(datum, mode, seventh),
+			frequenciesToMidi(frequencies),
+		);
 	}
 
 	setPointerChordName(pointerId, chordName);
-	startChord(
-		chordFrequencies(datum, mode, seventh),
-		settings.activeVoice as OscillatorType,
-		pointerId,
-	);
+	startChord(frequencies, settings.activeVoice as OscillatorType, pointerId);
 }
 
 function playChordFromElement(element: SVGPathElement, pointerId: number) {

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -406,8 +406,8 @@ describe("Instrument", () => {
 			await tick();
 
 			expect(progression.entries).toEqual([
-				{ kind: "chord", label: "C" },
-				{ kind: "chord", label: "Am" },
+				{ kind: "chord", label: "C", notes: [60, 64, 67] },
+				{ kind: "chord", label: "Am", notes: [69, 72, 76] },
 			]);
 		});
 
@@ -420,7 +420,9 @@ describe("Instrument", () => {
 
 			await pressChord(cWedge, 1);
 
-			expect(progression.entries).toEqual([{ kind: "chord", label: "C7" }]);
+			expect(progression.entries).toEqual([
+				{ kind: "chord", label: "C7", notes: [60, 64, 67, 70] },
+			]);
 		});
 
 		it("does not re-record when a replay leaves the chord name unchanged", async () => {
@@ -435,7 +437,9 @@ describe("Instrument", () => {
 			settings.seventhType = "major7";
 			await tick();
 
-			expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
+			expect(progression.entries).toEqual([
+				{ kind: "chord", label: "C", notes: [60, 64, 67] },
+			]);
 		});
 	});
 

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -2,6 +2,8 @@
 @component
 Progression pad
 - A simple tracker: every chord played is jotted onto the pad
+- play/stop plays the jotted progression through the app synth; export midi
+  downloads it as a .mid file
 - Line break / undo / clear controls; pause stops jotting; the X hides the
   pad (re-enable from settings); content persists in localStorage
 - Hidden until the first chord is played
@@ -15,27 +17,59 @@ import {
 	progression,
 	togglePaused,
 } from "$stores/progression.svelte";
+import {
+	player,
+	playProgression,
+	stopPlayback,
+} from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
-// Group flat entries into visual lines at each break
+import { progressionToMidi } from "$utils/midi";
+
+// Group flat entries into visual lines at each break, keeping each chord's
+// index into progression.entries so the sounding chord can be highlighted
 const lines = $derived.by(() => {
-	const grouped: string[][] = [[]];
-	for (const entry of progression.entries) {
+	const grouped: { label: string; index: number }[][] = [[]];
+	progression.entries.forEach((entry, index) => {
 		if (entry.kind === "break") {
 			grouped.push([]);
 		} else {
-			grouped[grouped.length - 1].push(entry.label);
+			grouped[grouped.length - 1].push({ label: entry.label, index });
 		}
-	}
+	});
 	return grouped;
 });
+
+const hasPlayableEntries = $derived(
+	progression.entries.some(
+		(entry) => entry.kind === "chord" && entry.notes.length > 0,
+	),
+);
 
 function dismiss() {
 	settings.showProgressionPad = false;
 }
 
+function exportMidi() {
+	const bytes = progressionToMidi(progression.entries);
+	const blob = new Blob([bytes], { type: "audio/midi" });
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement("a");
+	anchor.href = url;
+	anchor.download = "progression.mid";
+	anchor.click();
+	URL.revokeObjectURL(url);
+}
+
+// Silence playback if the pad unmounts (dismissed / mode change)
+$effect(() => {
+	return () => {
+		stopPlayback();
+	};
+});
+
 const buttonClasses =
-	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60";
+	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60 disabled:opacity-30 disabled:cursor-default";
 </script>
 
 {#if progression.entries.length > 0}
@@ -57,13 +91,28 @@ const buttonClasses =
 		>
 			{#each lines as line}
 				<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
-					{#each line as label}
-						<span class="opacity-90">{label}</span>
+					{#each line as chip}
+						<span
+							class={player.position === chip.index
+								? "text-accent"
+								: "opacity-90"}
+						>{chip.label}</span>
 					{/each}
 				</div>
 			{/each}
 		</div>
-		<div class="flex gap-2">
+		<div class="flex flex-wrap gap-2">
+			<button
+				type="button"
+				class="{buttonClasses} {player.playing ? 'text-accent border-accent/60' : ''}"
+				disabled={!hasPlayableEntries}
+				title={player.playing
+					? "Stop playback"
+					: "Play this progression"}
+				onclick={player.playing ? stopPlayback : playProgression}
+			>
+				{player.playing ? "stop" : "play"}
+			</button>
 			<button
 				type="button"
 				class="{buttonClasses} {progression.paused ? 'text-accent border-accent/60' : ''}"
@@ -83,6 +132,15 @@ const buttonClasses =
 			</button>
 			<button type="button" class={buttonClasses} onclick={clearProgression}>
 				clear
+			</button>
+			<button
+				type="button"
+				class={buttonClasses}
+				disabled={!hasPlayableEntries}
+				title="Download this progression as a .mid file"
+				onclick={exportMidi}
+			>
+				export midi
 			</button>
 		</div>
 	</div>

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -12,7 +12,7 @@ import { settings } from "$stores/settings.svelte";
 
 import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("ProgressionPad", () => {
 	beforeEach(() => {
@@ -81,6 +81,44 @@ describe("ProgressionPad", () => {
 		expect(progression.entries).toHaveLength(1);
 	});
 
+	it("disables play and export when no entry has note data", () => {
+		recordChord("C"); // legacy-style, no notes
+		render(ProgressionPad);
+		expect(screen.getByRole("button", { name: "play" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "export midi" })).toBeDisabled();
+	});
+
+	it("exports the progression as a .mid download", async () => {
+		const user = userEvent.setup();
+		recordChord("C", [60, 64, 67]);
+		render(ProgressionPad);
+
+		const exported: Blob[] = [];
+		const createObjectURL = vi.fn((blob: Blob) => {
+			exported.push(blob);
+			return "blob:fake";
+		});
+		vi.stubGlobal("URL", {
+			...URL,
+			createObjectURL,
+			revokeObjectURL: vi.fn(),
+		});
+		const click = vi
+			.spyOn(HTMLAnchorElement.prototype, "click")
+			.mockImplementation(() => {});
+
+		await user.click(screen.getByRole("button", { name: "export midi" }));
+
+		expect(createObjectURL).toHaveBeenCalledTimes(1);
+		expect(exported).toHaveLength(1);
+		const bytes = new Uint8Array(await exported[0].arrayBuffer());
+		// "MThd" — a Standard MIDI File header
+		expect(Array.from(bytes.slice(0, 4))).toEqual([0x4d, 0x54, 0x68, 0x64]);
+
+		click.mockRestore();
+		vi.unstubAllGlobals();
+	});
+
 	it("wires the new line, undo, and clear controls", async () => {
 		const user = userEvent.setup();
 		recordChord("C");
@@ -91,7 +129,11 @@ describe("ProgressionPad", () => {
 		expect(progression.entries.at(-1)).toEqual({ kind: "break" });
 
 		await user.click(screen.getByRole("button", { name: "undo" }));
-		expect(progression.entries.at(-1)).toEqual({ kind: "chord", label: "G" });
+		expect(progression.entries.at(-1)).toEqual({
+			kind: "chord",
+			label: "G",
+			notes: [],
+		});
 
 		await user.click(screen.getByRole("button", { name: "clear" }));
 		expect(progression.entries).toEqual([]);

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -168,5 +168,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.8.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.9.0</div>
 </div>

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -11,7 +11,7 @@ import {
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-const STORAGE_KEY = "fifths-progression";
+const STORAGE_KEY = "fifths-progression-v2";
 
 function stored() {
 	return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
@@ -29,13 +29,15 @@ describe("progression store", () => {
 		togglePaused();
 		expect(progression.paused).toBe(true);
 		recordChord("G");
-		expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C", notes: [] },
+		]);
 
 		togglePaused();
 		recordChord("Am");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C" },
-			{ kind: "chord", label: "Am" },
+			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "Am", notes: [] },
 		]);
 	});
 
@@ -44,9 +46,9 @@ describe("progression store", () => {
 		recordChord("Am");
 		recordChord("F7");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C" },
-			{ kind: "chord", label: "Am" },
-			{ kind: "chord", label: "F7" },
+			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "Am", notes: [] },
+			{ kind: "chord", label: "F7", notes: [] },
 		]);
 	});
 
@@ -59,9 +61,9 @@ describe("progression store", () => {
 		addLineBreak(); // doubled — ignored
 		recordChord("G");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C" },
+			{ kind: "chord", label: "C", notes: [] },
 			{ kind: "break" },
-			{ kind: "chord", label: "G" },
+			{ kind: "chord", label: "G", notes: [] },
 		]);
 	});
 
@@ -69,7 +71,9 @@ describe("progression store", () => {
 		recordChord("C");
 		recordChord("G");
 		deleteLast();
-		expect(progression.entries).toEqual([{ kind: "chord", label: "C" }]);
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C", notes: [] },
+		]);
 		deleteLast();
 		deleteLast(); // empty — no throw
 		expect(progression.entries).toEqual([]);
@@ -86,12 +90,12 @@ describe("progression store", () => {
 
 	it("persists every mutation to localStorage", () => {
 		recordChord("C");
-		expect(stored()).toEqual([{ kind: "chord", label: "C" }]);
+		expect(stored()).toEqual([{ kind: "chord", label: "C", notes: [] }]);
 		addLineBreak();
 		recordChord("G");
 		deleteLast();
 		expect(stored()).toEqual([
-			{ kind: "chord", label: "C" },
+			{ kind: "chord", label: "C", notes: [] },
 			{ kind: "break" },
 		]);
 	});

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -2,10 +2,25 @@
 // persisted to localStorage so a work-in-progress survives reloads.
 
 export type ProgressionEntry =
-	| { kind: "chord"; label: string }
+	| { kind: "chord"; label: string; notes: number[] }
 	| { kind: "break" };
 
-const STORAGE_KEY = "fifths-progression";
+// v2: chord entries carry MIDI note numbers (for playback and .mid export).
+// The key was bumped from "fifths-progression", intentionally abandoning
+// note-less v1 jottings.
+const STORAGE_KEY = "fifths-progression-v2";
+
+function isValidEntry(entry: unknown): entry is ProgressionEntry {
+	if (typeof entry !== "object" || entry === null) return false;
+	const candidate = entry as Partial<ProgressionEntry>;
+	if (candidate.kind === "break") return true;
+	return (
+		candidate.kind === "chord" &&
+		typeof candidate.label === "string" &&
+		Array.isArray(candidate.notes) &&
+		candidate.notes.every((note) => typeof note === "number")
+	);
+}
 
 // Guarded for SSR/prerender, where localStorage does not exist
 function loadEntries(): ProgressionEntry[] {
@@ -15,11 +30,7 @@ function loadEntries(): ProgressionEntry[] {
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		if (!Array.isArray(parsed)) return [];
-		return parsed.filter(
-			(entry): entry is ProgressionEntry =>
-				entry?.kind === "break" ||
-				(entry?.kind === "chord" && typeof entry.label === "string"),
-		);
+		return parsed.filter(isValidEntry);
 	} catch {
 		return [];
 	}
@@ -41,10 +52,11 @@ export const progression = $state({
 	paused: false,
 });
 
-// Append a played chord (called by the Instrument on each distinct chord)
-export function recordChord(label: string): void {
+// Append a played chord (called by the Instrument on each distinct chord).
+// `notes` are MIDI note numbers, used for pad playback and .mid export.
+export function recordChord(label: string, notes: number[] = []): void {
 	if (progression.paused) return;
-	progression.entries.push({ kind: "chord", label });
+	progression.entries.push({ kind: "chord", label, notes });
 	persist();
 }
 

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -1,0 +1,125 @@
+// Tests for the progression player (pad playback through the app synth).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$stores/audio.svelte", () => ({
+	startChord: vi.fn(),
+	stopChordById: vi.fn(),
+}));
+
+import { startChord, stopChordById } from "$stores/audio.svelte";
+import {
+	addLineBreak,
+	clearProgression,
+	progression,
+	recordChord,
+} from "$stores/progression.svelte";
+import {
+	player,
+	playProgression,
+	stopPlayback,
+} from "$stores/progressionPlayer.svelte";
+import { settings } from "$stores/settings.svelte";
+
+const STEP_MS = 500;
+const C_NOTES = [60, 64, 67];
+const G_NOTES = [55, 59, 62];
+
+describe("progression player", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// Reset player state BEFORE clearing mocks — stopPlayback itself
+		// calls the mocked stopChordById
+		stopPlayback();
+		vi.clearAllMocks();
+		clearProgression();
+		progression.paused = false;
+		settings.activeVoice = "sine";
+	});
+
+	afterEach(() => {
+		stopPlayback();
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+	});
+
+	it("plays each chord in sequence with the reserved pointer id", () => {
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		expect(player.playing).toBe(true);
+		expect(player.position).toBe(0);
+		expect(startChord).toHaveBeenCalledTimes(1);
+		const [frequencies, voice, pointerId] = vi.mocked(startChord).mock.calls[0];
+		expect(pointerId).toBe(-1);
+		expect(voice).toBe("sine");
+		expect(frequencies[0]).toBeCloseTo(261.63, 1); // C4 from MIDI 60
+
+		vi.advanceTimersByTime(STEP_MS);
+		expect(player.position).toBe(1);
+		expect(startChord).toHaveBeenCalledTimes(2);
+	});
+
+	it("releases each chord before the next step", () => {
+		recordChord("C", C_NOTES);
+		playProgression();
+		expect(stopChordById).not.toHaveBeenCalledWith(-1);
+
+		vi.advanceTimersByTime(STEP_MS - 1);
+		expect(stopChordById).toHaveBeenCalledWith(-1);
+	});
+
+	it("rests on line breaks", () => {
+		recordChord("C", C_NOTES);
+		addLineBreak();
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		vi.advanceTimersByTime(STEP_MS); // now on the break
+		expect(player.position).toBe(1);
+		expect(startChord).toHaveBeenCalledTimes(1); // no new chord
+
+		vi.advanceTimersByTime(STEP_MS); // now on G
+		expect(startChord).toHaveBeenCalledTimes(2);
+	});
+
+	it("stops at the end and resets position", () => {
+		recordChord("C", C_NOTES);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS);
+
+		expect(player.playing).toBe(false);
+		expect(player.position).toBe(-1);
+		expect(stopChordById).toHaveBeenCalledWith(-1);
+	});
+
+	it("can be stopped mid-playback", () => {
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		stopPlayback();
+		expect(player.playing).toBe(false);
+		expect(stopChordById).toHaveBeenCalledWith(-1);
+
+		vi.advanceTimersByTime(STEP_MS * 4);
+		expect(startChord).toHaveBeenCalledTimes(1); // no further steps
+	});
+
+	it("handles entries shrinking during playback (clear)", () => {
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		clearProgression();
+		vi.advanceTimersByTime(STEP_MS);
+		expect(player.playing).toBe(false);
+	});
+
+	it("does nothing on an empty pad", () => {
+		playProgression();
+		expect(player.playing).toBe(false);
+		expect(startChord).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -1,0 +1,72 @@
+// Plays the jotted progression back through the app's own synth. Playback
+// goes straight to the audio store with a reserved pointer ID, bypassing the
+// Instrument's jotting path — so playback never re-records itself.
+
+import { startChord, stopChordById } from "$stores/audio.svelte";
+import { progression } from "$stores/progression.svelte";
+import { settings } from "$stores/settings.svelte";
+
+import { midiToFrequency } from "$utils/midi";
+
+// Reserved pointer ID for programmatic playback (never a real pointer)
+const PLAYBACK_POINTER_ID = -1;
+
+// Uniform step timing until the transport (Phase B) brings a real BPM:
+// 120 BPM quarter notes, with a short release before the next chord
+const STEP_MS = 500;
+const RELEASE_MS = 420;
+
+export const player = $state({
+	playing: false,
+	// Index into progression.entries of the sounding chord, -1 when idle
+	position: -1,
+});
+
+let stepTimeout: ReturnType<typeof setTimeout> | null = null;
+let releaseTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function clearTimers(): void {
+	if (stepTimeout) clearTimeout(stepTimeout);
+	if (releaseTimeout) clearTimeout(releaseTimeout);
+	stepTimeout = null;
+	releaseTimeout = null;
+}
+
+function step(index: number): void {
+	// Entries can shrink mid-playback (undo/clear) — re-check every step
+	if (!player.playing || index >= progression.entries.length) {
+		stopPlayback();
+		return;
+	}
+
+	const entry = progression.entries[index];
+	player.position = index;
+
+	if (entry.kind === "chord" && entry.notes.length > 0) {
+		startChord(
+			entry.notes.map(midiToFrequency),
+			settings.activeVoice as OscillatorType,
+			PLAYBACK_POINTER_ID,
+		);
+		releaseTimeout = setTimeout(() => {
+			stopChordById(PLAYBACK_POINTER_ID);
+		}, RELEASE_MS);
+	}
+	// Breaks (and legacy note-less chords) simply rest for a step
+
+	stepTimeout = setTimeout(() => step(index + 1), STEP_MS);
+}
+
+export function playProgression(): void {
+	if (player.playing) return;
+	if (progression.entries.length === 0) return;
+	player.playing = true;
+	step(0);
+}
+
+export function stopPlayback(): void {
+	clearTimers();
+	stopChordById(PLAYBACK_POINTER_ID);
+	player.playing = false;
+	player.position = -1;
+}

--- a/src/lib/utils/midi.test.ts
+++ b/src/lib/utils/midi.test.ts
@@ -1,0 +1,135 @@
+import type { ProgressionEntry } from "$stores/progression.svelte";
+
+import { describe, expect, it } from "vitest";
+import {
+	encodeVariableLength,
+	frequenciesToMidi,
+	frequencyToMidi,
+	midiToFrequency,
+	progressionToMidi,
+} from "./midi";
+
+const C_MAJOR_NOTES = [60, 64, 67]; // C4 E4 G4
+
+describe("frequencyToMidi", () => {
+	it("maps A440 tuning to MIDI note numbers", () => {
+		expect(frequencyToMidi(440)).toBe(69); // A4
+		expect(frequencyToMidi(261.63)).toBe(60); // middle C
+		expect(frequencyToMidi(466.16)).toBe(70); // Bb4
+		expect(frequencyToMidi(220)).toBe(57); // A3
+	});
+
+	it("maps chord frequency arrays", () => {
+		expect(frequenciesToMidi([261.63, 329.63, 392])).toEqual(C_MAJOR_NOTES);
+	});
+
+	it("round-trips with midiToFrequency", () => {
+		for (const note of [21, 57, 60, 69, 70, 108]) {
+			expect(frequencyToMidi(midiToFrequency(note))).toBe(note);
+		}
+	});
+});
+
+describe("encodeVariableLength", () => {
+	it("encodes 7-bit values as single bytes", () => {
+		expect(encodeVariableLength(0)).toEqual([0x00]);
+		expect(encodeVariableLength(127)).toEqual([0x7f]);
+	});
+
+	it("encodes multi-byte values with continuation bits", () => {
+		expect(encodeVariableLength(128)).toEqual([0x81, 0x00]);
+		expect(encodeVariableLength(480)).toEqual([0x83, 0x60]);
+		expect(encodeVariableLength(0x0fffff)).toEqual([0xbf, 0xff, 0x7f]);
+	});
+
+	it("rejects negative deltas", () => {
+		expect(() => encodeVariableLength(-1)).toThrow();
+	});
+});
+
+describe("progressionToMidi", () => {
+	const cChord: ProgressionEntry = {
+		kind: "chord",
+		label: "C",
+		notes: C_MAJOR_NOTES,
+	};
+	const lineBreak: ProgressionEntry = { kind: "break" };
+
+	function bytesOf(entries: ProgressionEntry[]): number[] {
+		return Array.from(progressionToMidi(entries));
+	}
+
+	it("starts with a valid format-0 header at 480 ticks per quarter", () => {
+		const bytes = bytesOf([cChord]);
+		// "MThd", length 6, format 0, 1 track, division 480
+		expect(bytes.slice(0, 14)).toEqual([
+			0x4d, 0x54, 0x68, 0x64, 0, 0, 0, 6, 0, 0, 0, 1, 0x01, 0xe0,
+		]);
+	});
+
+	it("contains a track chunk whose declared length matches its events", () => {
+		const bytes = bytesOf([cChord]);
+		expect(bytes.slice(14, 18)).toEqual([0x4d, 0x54, 0x72, 0x6b]); // "MTrk"
+		const declared =
+			(bytes[18] << 24) | (bytes[19] << 16) | (bytes[20] << 8) | bytes[21];
+		expect(bytes.length).toBe(22 + declared);
+	});
+
+	it("writes a tempo meta event for the requested BPM", () => {
+		const bytes = bytesOf([cChord]);
+		// 120 BPM = 500000 us per quarter = 0x07 0xA1 0x20
+		expect(bytes.slice(22, 29)).toEqual([
+			0x00, 0xff, 0x51, 0x03, 0x07, 0xa1, 0x20,
+		]);
+	});
+
+	it("emits a note-on and note-off pair per chord note", () => {
+		const bytes = bytesOf([cChord]);
+		const noteOns = bytes.filter((b) => b === 0x90).length;
+		const noteOffs = bytes.filter((b) => b === 0x80).length;
+		expect(noteOns).toBe(3);
+		expect(noteOffs).toBe(3);
+	});
+
+	it("holds each chord for one quarter note", () => {
+		const bytes = bytesOf([{ kind: "chord", label: "A", notes: [69] }]);
+		// After the tempo event: delta 0, note-on 69; delta 480, note-off 69
+		expect(bytes.slice(29)).toEqual([
+			0x00,
+			0x90,
+			69,
+			96, // note on, velocity 96
+			0x83,
+			0x60,
+			0x80,
+			69,
+			0, // 480 ticks later, note off
+			0x00,
+			0xff,
+			0x2f,
+			0x00, // end of track
+		]);
+	});
+
+	it("turns line breaks into one-quarter rests before the next chord", () => {
+		const single = bytesOf([cChord, cChord]);
+		const withBreak = bytesOf([cChord, lineBreak, cChord]);
+		// The second chord's first note-on delta grows from 0 to 480 (1 extra
+		// byte for the variable-length delta)
+		expect(withBreak.length).toBe(single.length + 1);
+		const secondOnDelta = withBreak.indexOf(0x90, 40);
+		expect(withBreak.slice(secondOnDelta - 2, secondOnDelta)).toEqual([
+			0x83, 0x60,
+		]);
+	});
+
+	it("skips legacy chords without note data", () => {
+		const bytes = bytesOf([{ kind: "chord", label: "C", notes: [] }]);
+		expect(bytes.filter((b) => b === 0x90)).toHaveLength(0);
+	});
+
+	it("ends with an end-of-track meta event", () => {
+		const bytes = bytesOf([cChord]);
+		expect(bytes.slice(-4)).toEqual([0x00, 0xff, 0x2f, 0x00]);
+	});
+});

--- a/src/lib/utils/midi.ts
+++ b/src/lib/utils/midi.ts
@@ -1,0 +1,134 @@
+/**
+ * MIDI utilities: note/frequency conversion and a minimal Standard MIDI File
+ * (SMF format 0) writer for exporting jotted progressions. Hand-rolled and
+ * dependency-free — the format is a header chunk plus one track chunk of
+ * delta-timed note events.
+ */
+
+import type { ProgressionEntry } from "$stores/progression.svelte";
+
+// A440 equal temperament: MIDI note 69 = A4 = 440 Hz
+export function frequencyToMidi(frequency: number): number {
+	return Math.round(69 + 12 * Math.log2(frequency / 440));
+}
+
+export function frequenciesToMidi(frequencies: number[]): number[] {
+	return frequencies.map(frequencyToMidi);
+}
+
+// Inverse, rounded to the project's 2-decimal frequency convention
+export function midiToFrequency(note: number): number {
+	return Math.round(440 * 2 ** ((note - 69) / 12) * 100) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Standard MIDI File writer
+// ---------------------------------------------------------------------------
+
+const TICKS_PER_QUARTER = 480;
+const NOTE_VELOCITY = 96;
+
+// MIDI delta times are variable-length quantities: 7 bits per byte, high bit
+// set on every byte except the last
+export function encodeVariableLength(value: number): number[] {
+	if (value < 0) throw new Error(`negative delta time: ${value}`);
+	const bytes = [value & 0x7f];
+	let remaining = value >> 7;
+	while (remaining > 0) {
+		bytes.unshift((remaining & 0x7f) | 0x80);
+		remaining >>= 7;
+	}
+	return bytes;
+}
+
+function uint32(value: number): number[] {
+	return [
+		(value >> 24) & 0xff,
+		(value >> 16) & 0xff,
+		(value >> 8) & 0xff,
+		value & 0xff,
+	];
+}
+
+function uint16(value: number): number[] {
+	return [(value >> 8) & 0xff, value & 0xff];
+}
+
+/**
+ * Build a format-0 .mid file from progression entries.
+ * Each chord lasts one quarter note; line breaks become one-quarter rests.
+ * Entries without note data (legacy jottings) are skipped.
+ */
+export function progressionToMidi(
+	entries: ProgressionEntry[],
+	tempoBpm = 120,
+): Uint8Array<ArrayBuffer> {
+	const events: number[] = [];
+
+	// Tempo meta event at tick 0 (microseconds per quarter note)
+	const microsPerQuarter = Math.round(60_000_000 / tempoBpm);
+	events.push(
+		0x00,
+		0xff,
+		0x51,
+		0x03,
+		(microsPerQuarter >> 16) & 0xff,
+		(microsPerQuarter >> 8) & 0xff,
+		microsPerQuarter & 0xff,
+	);
+
+	// Delta time owed to the next event (accumulates across rests/skips)
+	let pendingDelta = 0;
+
+	for (const entry of entries) {
+		if (entry.kind === "break") {
+			pendingDelta += TICKS_PER_QUARTER;
+			continue;
+		}
+		if (entry.notes.length === 0) continue;
+
+		// Note-ons: first carries the pending delta, the rest are simultaneous
+		entry.notes.forEach((note, i) => {
+			events.push(
+				...encodeVariableLength(i === 0 ? pendingDelta : 0),
+				0x90,
+				note & 0x7f,
+				NOTE_VELOCITY,
+			);
+		});
+		// Note-offs one quarter note later
+		entry.notes.forEach((note, i) => {
+			events.push(
+				...encodeVariableLength(i === 0 ? TICKS_PER_QUARTER : 0),
+				0x80,
+				note & 0x7f,
+				0x00,
+			);
+		});
+		pendingDelta = 0;
+	}
+
+	// End-of-track meta event
+	events.push(0x00, 0xff, 0x2f, 0x00);
+
+	const header = [
+		0x4d,
+		0x54,
+		0x68,
+		0x64, // "MThd"
+		...uint32(6), // header length
+		...uint16(0), // format 0
+		...uint16(1), // one track
+		...uint16(TICKS_PER_QUARTER),
+	];
+	const track = [
+		0x4d,
+		0x54,
+		0x72,
+		0x6b, // "MTrk"
+		...uint32(events.length),
+		...events,
+	];
+
+	return new Uint8Array([...header, ...track]);
+}


### PR DESCRIPTION
## Summary

The M1–M3 MIDI package for the progression pad:

**M1 — note data**: jotted chords now record MIDI note numbers, converted exactly from the app's equal-tempered frequencies at jot time. Storage schema bumped to v2 (pre-MIDI jottings intentionally abandoned per discussion).

**M2 — pad playback**: **play/stop** on the pad plays the progression through the app synth (uniform 120 BPM steps until the Phase B transport brings a real tempo). Playback uses a reserved pointer ID and bypasses the Instrument's jotting path, so it can never re-record itself. The sounding chord highlights in the pad; line breaks rest a step; undo/clear mid-playback ends safely.

**M3 — .mid export**: a hand-rolled, dependency-free Standard MIDI File (format 0) writer — tempo meta event, variable-length deltas, note-on/off pairs. **export midi** downloads `progression.mid`, ready for any DAW. Each chord is a quarter note; breaks become rests. play/export disable when no entry has note data.

## Test plan
- [x] 246 tests passing (+23): byte-level SMF assertions (header, track length declaration, tempo bytes, VLQ encoding incl. multi-byte, rest deltas), frequency↔MIDI round-trips, player sequencing on fake timers, export blob header, exact-notes jotting assertions
- [x] svelte-check, biome, build clean
- [ ] Manual: jot a progression → play (chords highlight in sequence) → export midi → open the file in a DAW/GarageBand and confirm pitches