### PR TITLE
feat: pad transport, punch-in recording, and tempo/rhythm (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-07-12
+
+### Added
+- Progression pad transport: **pause** is now a true playback pause (position kept, resume from the same chord), plus a **stop** button and a **loop** toggle
+- **● rec** toggle replaces the old pause-jotting button — off means noodle freely without jotting
+- Punch-in continuation: while the transport runs, live jotting is suspended (playing along can't jot into the progression being played); when playback reaches its natural end with rec on, the next chord you play appends — press play, listen to the end, keep going
+- **Tempo**: a BPM control on the pad (40–240, persisted) drives playback and MIDI export
+- **Rhythm from hold duration**: how long you hold each chord is quantized to 1, 2, or 4 beats at the pad's tempo — playback and .mid export reproduce your long and short chords on a clean grid
+
+### Changed
+- MIDI export honors per-chord beats and the pad's BPM
+
 ## [0.9.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.9.0
+**Current Version**: 0.10.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -26,7 +26,8 @@ import {
 	unlockAudio,
 } from "$stores/audio.svelte";
 import { performance } from "$stores/performance.svelte";
-import { recordChord } from "$stores/progression.svelte";
+import { recordChord, setEntryBeats } from "$stores/progression.svelte";
+import { player } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
 // types
@@ -45,7 +46,14 @@ import { textCoords, wedgePath } from "$utils/circleGeometry";
 import { processChordEnharmonics } from "$utils/enharmonics";
 import { frequenciesToMidi } from "$utils/midi";
 import { CHROMATIC_NOTES, getNoteForPosition } from "$utils/noteHelpers";
+import { beatsFromHold } from "$utils/rhythm";
 import { seventhChordName, withSeventh } from "$utils/sevenths";
+
+// A jotted entry whose hold duration is still open (finalized on release)
+interface OpenRecord {
+	index: number;
+	start: number;
+}
 
 // Track active playback - Map pointer IDs to their elements and chord names
 const activePointers = $state(
@@ -57,6 +65,8 @@ const activePointers = $state(
 			chordName: string;
 			// Per-pointer seventh upgrade (a second finger on this wedge)
 			seventh: boolean;
+			// The pad entry this pointer is currently holding open, if any
+			openRecord: OpenRecord | null;
 		}
 	>(),
 );
@@ -153,18 +163,35 @@ function playChordAtIndex(index: number, mode: string, pointerId: number) {
 	const frequencies = chordFrequencies(datum, mode, seventh);
 
 	// Jot every distinct chord this pointer sounds (new press, slide to a
-	// new wedge, or a seventh change) onto the progression pad
-	const previousName = activePointers.get(pointerId)?.chordName;
+	// new wedge, or a seventh change) onto the progression pad. The entry's
+	// duration stays open until the pointer releases or moves on.
+	const pointerInfo = activePointers.get(pointerId);
 	const chordName = chordDisplayName(datum, mode, seventh);
-	if (chordName !== previousName) {
-		recordChord(
+	if (pointerInfo && chordName !== pointerInfo.chordName) {
+		closeOpenRecord(pointerInfo);
+		const index = recordChord(
 			chordSymbol(datum, mode, seventh),
 			frequenciesToMidi(frequencies),
 		);
+		if (index >= 0) {
+			pointerInfo.openRecord = { index, start: Date.now() };
+		}
 	}
 
 	setPointerChordName(pointerId, chordName);
 	startChord(frequencies, settings.activeVoice as OscillatorType, pointerId);
+}
+
+// Finalize an open pad entry's duration from how long it was held,
+// quantized to the pad's tempo
+function closeOpenRecord(pointerInfo: { openRecord: OpenRecord | null }) {
+	if (!pointerInfo.openRecord) return;
+	const heldMs = Date.now() - pointerInfo.openRecord.start;
+	setEntryBeats(
+		pointerInfo.openRecord.index,
+		beatsFromHold(heldMs, player.bpm),
+	);
+	pointerInfo.openRecord = null;
 }
 
 function playChordFromElement(element: SVGPathElement, pointerId: number) {
@@ -211,6 +238,7 @@ function onPressStart(event: PointerEvent) {
 		elementId: target.id,
 		chordName: "",
 		seventh: false,
+		openRecord: null,
 	});
 	currentPointerId = pointerId;
 
@@ -264,6 +292,7 @@ function onPointerMove(event: PointerEvent) {
 			elementId: element.id,
 			chordName: pointerInfo.chordName,
 			seventh: pointerInfo.seventh,
+			openRecord: pointerInfo.openRecord,
 		});
 
 		// Play new chord (this will stop the previous chord for this pointer)
@@ -286,7 +315,11 @@ function releasePointer(pointerId: number): boolean {
 		return true;
 	}
 
-	if (!activePointers.has(pointerId)) return false;
+	const pointerInfo = activePointers.get(pointerId);
+	if (!pointerInfo) return false;
+
+	// Finalize the jotted entry's duration from the hold length
+	closeOpenRecord(pointerInfo);
 
 	// Stop the chord for this pointer and drop any upgrade aimed at it
 	stopChordById(pointerId);

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -406,8 +406,8 @@ describe("Instrument", () => {
 			await tick();
 
 			expect(progression.entries).toEqual([
-				{ kind: "chord", label: "C", notes: [60, 64, 67] },
-				{ kind: "chord", label: "Am", notes: [69, 72, 76] },
+				{ kind: "chord", label: "C", notes: [60, 64, 67], beats: 1 },
+				{ kind: "chord", label: "Am", notes: [69, 72, 76], beats: 1 },
 			]);
 		});
 
@@ -421,8 +421,25 @@ describe("Instrument", () => {
 			await pressChord(cWedge, 1);
 
 			expect(progression.entries).toEqual([
-				{ kind: "chord", label: "C7", notes: [60, 64, 67, 70] },
+				{ kind: "chord", label: "C7", notes: [60, 64, 67, 70], beats: 1 },
 			]);
+		});
+
+		it("quantizes a chord's held duration into beats on release", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			if (!cWedge) throw new Error("C wedge not found");
+
+			// pressChord already advances 150ms (unlock delay); hold ~1.1s
+			// total — at 120 BPM that's ~2.2 beats, quantized to a half note
+			await pressChord(cWedge, 1);
+			vi.advanceTimersByTime(950);
+			releasePointer(cWedge, 1);
+			await tick();
+
+			const entry = progression.entries[0];
+			if (entry.kind !== "chord") throw new Error("expected chord entry");
+			expect(entry.beats).toBe(2);
 		});
 
 		it("does not re-record when a replay leaves the chord name unchanged", async () => {
@@ -438,7 +455,7 @@ describe("Instrument", () => {
 			await tick();
 
 			expect(progression.entries).toEqual([
-				{ kind: "chord", label: "C", notes: [60, 64, 67] },
+				{ kind: "chord", label: "C", notes: [60, 64, 67], beats: 1 },
 			]);
 		});
 	});

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -1,12 +1,14 @@
 <!--
 @component
 Progression pad
-- A simple tracker: every chord played is jotted onto the pad
-- play/stop plays the jotted progression through the app synth; export midi
-  downloads it as a .mid file
-- Line break / undo / clear controls; pause stops jotting; the X hides the
-  pad (re-enable from settings); content persists in localStorage
-- Hidden until the first chord is played
+- A simple tracker: every chord played is jotted onto the pad (with its
+  hold duration quantized to beats at the pad's tempo)
+- Transport: play/pause (true pause, position kept), stop, loop; while the
+  transport is engaged, live jotting is suspended — when playback ends
+  naturally with rec on, the next chord played appends (punch-in)
+- ● rec toggles jotting; export midi downloads a .mid at the pad's BPM
+- Line break / undo / clear; the X hides the pad (re-enable from settings);
+  content persists in localStorage; hidden until the first chord is played
 -->
 
 <script lang="ts">
@@ -15,12 +17,15 @@ import {
 	clearProgression,
 	deleteLast,
 	progression,
-	togglePaused,
+	toggleRecording,
 } from "$stores/progression.svelte";
 import {
+	pausePlayback,
 	player,
 	playProgression,
+	setBpm,
 	stopPlayback,
+	toggleLoop,
 } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
@@ -46,12 +51,14 @@ const hasPlayableEntries = $derived(
 	),
 );
 
+const transportRunning = $derived(player.playing && !player.paused);
+
 function dismiss() {
 	settings.showProgressionPad = false;
 }
 
 function exportMidi() {
-	const bytes = progressionToMidi(progression.entries);
+	const bytes = progressionToMidi(progression.entries, player.bpm);
 	const blob = new Blob([bytes], { type: "audio/midi" });
 	const url = URL.createObjectURL(blob);
 	const anchor = document.createElement("a");
@@ -70,6 +77,7 @@ $effect(() => {
 
 const buttonClasses =
 	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60 disabled:opacity-30 disabled:cursor-default";
+const activeClasses = "text-accent border-accent/60";
 </script>
 
 {#if progression.entries.length > 0}
@@ -101,29 +109,69 @@ const buttonClasses =
 				</div>
 			{/each}
 		</div>
-		<div class="flex flex-wrap gap-2">
+
+		<div class="flex flex-wrap items-center gap-2">
+			<!-- transport -->
 			<button
 				type="button"
-				class="{buttonClasses} {player.playing ? 'text-accent border-accent/60' : ''}"
+				class="{buttonClasses} {transportRunning ? activeClasses : ''}"
 				disabled={!hasPlayableEntries}
-				title={player.playing
-					? "Stop playback"
+				title={transportRunning
+					? "Pause playback"
 					: "Play this progression"}
-				onclick={player.playing ? stopPlayback : playProgression}
+				onclick={transportRunning ? pausePlayback : playProgression}
 			>
-				{player.playing ? "stop" : "play"}
+				{transportRunning ? "pause" : "play"}
 			</button>
 			<button
 				type="button"
-				class="{buttonClasses} {progression.paused ? 'text-accent border-accent/60' : ''}"
-				aria-pressed={progression.paused}
-				title={progression.paused
-					? "Resume jotting chords"
-					: "Pause jotting chords"}
-				onclick={togglePaused}
+				class={buttonClasses}
+				disabled={!player.playing}
+				title="Stop playback"
+				onclick={stopPlayback}
 			>
-				{progression.paused ? "resume" : "pause"}
+				stop
 			</button>
+			<button
+				type="button"
+				class="{buttonClasses} {player.loop ? activeClasses : ''}"
+				aria-pressed={player.loop}
+				title="Loop playback"
+				onclick={toggleLoop}
+			>
+				loop
+			</button>
+
+			<!-- recorder -->
+			<button
+				type="button"
+				class="{buttonClasses} {progression.recording ? activeClasses : ''}"
+				aria-pressed={progression.recording}
+				title={progression.recording
+					? "Recording: chords you play are jotted (off = noodle freely)"
+					: "Not recording: chords you play are not jotted"}
+				onclick={toggleRecording}
+			>
+				&#9679; rec
+			</button>
+
+			<!-- tempo -->
+			<label class="flex items-center gap-1 text-xs opacity-80">
+				<input
+					type="number"
+					min="40"
+					max="240"
+					value={player.bpm}
+					onchange={(e) =>
+						setBpm(Number.parseInt(e.currentTarget.value, 10) || 120)}
+					class="w-14 rounded border border-neutral-100/30 bg-primary/20 px-1.5 py-1 text-xs tabular-nums"
+					aria-label="Tempo in beats per minute"
+				/>
+				bpm
+			</label>
+		</div>
+
+		<div class="flex flex-wrap gap-2">
 			<button type="button" class={buttonClasses} onclick={addLineBreak}>
 				new line
 			</button>
@@ -137,7 +185,7 @@ const buttonClasses =
 				type="button"
 				class={buttonClasses}
 				disabled={!hasPlayableEntries}
-				title="Download this progression as a .mid file"
+				title="Download this progression as a .mid file at the current BPM"
 				onclick={exportMidi}
 			>
 				export midi

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -8,16 +8,21 @@ import {
 	progression,
 	recordChord,
 } from "$stores/progression.svelte";
+import { player, setBpm, stopPlayback } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
-import { render, screen } from "@testing-library/svelte";
+import { fireEvent, render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("ProgressionPad", () => {
 	beforeEach(() => {
+		stopPlayback();
 		clearProgression();
-		progression.paused = false;
+		progression.recording = true;
+		progression.suspended = false;
+		player.loop = false;
+		setBpm(120);
 		settings.showProgressionPad = true;
 	});
 
@@ -48,24 +53,72 @@ describe("ProgressionPad", () => {
 		expect(rows[1]).toHaveTextContent("G");
 	});
 
-	it("toggles jotting with the pause button", async () => {
+	it("toggles jotting with the rec button", async () => {
 		const user = userEvent.setup();
 		recordChord("C");
 		render(ProgressionPad);
 
-		const pause = screen.getByRole("button", { name: "pause" });
-		expect(pause).toHaveAttribute("aria-pressed", "false");
-		await user.click(pause);
-		expect(progression.paused).toBe(true);
+		const rec = screen.getByRole("button", { name: "● rec" });
+		expect(rec).toHaveAttribute("aria-pressed", "true");
+		await user.click(rec);
+		expect(progression.recording).toBe(false);
 
-		// While paused, plays are not jotted
+		// With rec off, plays are not jotted
 		recordChord("G");
 		expect(progression.entries).toHaveLength(1);
 
-		const resume = screen.getByRole("button", { name: "resume" });
-		expect(resume).toHaveAttribute("aria-pressed", "true");
-		await user.click(resume);
-		expect(progression.paused).toBe(false);
+		await user.click(rec);
+		expect(progression.recording).toBe(true);
+	});
+
+	it("play becomes a true pause and stop resets", async () => {
+		const user = userEvent.setup();
+		recordChord("C", [60, 64, 67]);
+		recordChord("G", [55, 59, 62]);
+		render(ProgressionPad);
+
+		await user.click(screen.getByRole("button", { name: "play" }));
+		expect(player.playing).toBe(true);
+		expect(progression.suspended).toBe(true);
+
+		// The same slot is now a pause button; pausing keeps the position
+		await user.click(screen.getByRole("button", { name: "pause" }));
+		expect(player.paused).toBe(true);
+		expect(player.position).toBeGreaterThanOrEqual(0);
+		expect(progression.suspended).toBe(true); // transport still engaged
+
+		// stop disengages the transport and lifts the jotting suspension
+		await user.click(screen.getByRole("button", { name: "stop" }));
+		expect(player.playing).toBe(false);
+		expect(player.position).toBe(-1);
+		expect(progression.suspended).toBe(false);
+	});
+
+	it("toggles loop", async () => {
+		const user = userEvent.setup();
+		recordChord("C", [60, 64, 67]);
+		render(ProgressionPad);
+
+		const loop = screen.getByRole("button", { name: "loop" });
+		expect(loop).toHaveAttribute("aria-pressed", "false");
+		await user.click(loop);
+		expect(player.loop).toBe(true);
+	});
+
+	it("sets the tempo from the bpm input, clamped to range", async () => {
+		recordChord("C", [60, 64, 67]);
+		render(ProgressionPad);
+
+		const bpm = screen.getByLabelText(
+			"Tempo in beats per minute",
+		) as HTMLInputElement;
+		expect(bpm).toHaveValue(120);
+
+		await fireEvent.change(bpm, { target: { value: "90" } });
+		expect(player.bpm).toBe(90);
+
+		await fireEvent.change(bpm, { target: { value: "999" } });
+		expect(player.bpm).toBe(240);
 	});
 
 	it("dismisses the pad via the X (re-enabled from settings)", async () => {
@@ -133,6 +186,7 @@ describe("ProgressionPad", () => {
 			kind: "chord",
 			label: "G",
 			notes: [],
+			beats: 1,
 		});
 
 		await user.click(screen.getByRole("button", { name: "clear" }));

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -168,5 +168,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.9.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.10.0</div>
 </div>

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -6,7 +6,8 @@ import {
 	deleteLast,
 	progression,
 	recordChord,
-	togglePaused,
+	setEntryBeats,
+	toggleRecording,
 } from "$stores/progression.svelte";
 
 import { beforeEach, describe, expect, it } from "vitest";
@@ -20,25 +21,56 @@ function stored() {
 describe("progression store", () => {
 	beforeEach(() => {
 		clearProgression();
-		progression.paused = false;
+		progression.recording = true;
+		progression.suspended = false;
 		localStorage.clear();
 	});
 
-	it("does not record while paused, and resumes recording after", () => {
+	it("does not record with the rec toggle off, and resumes when back on", () => {
 		recordChord("C");
-		togglePaused();
-		expect(progression.paused).toBe(true);
+		toggleRecording();
+		expect(progression.recording).toBe(false);
 		recordChord("G");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
 		]);
 
-		togglePaused();
+		toggleRecording();
 		recordChord("Am");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
-			{ kind: "chord", label: "Am", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
+			{ kind: "chord", label: "Am", notes: [], beats: 1 },
 		]);
+	});
+
+	it("does not record while the transport suspends jotting", () => {
+		progression.suspended = true;
+		expect(recordChord("C")).toBe(-1);
+		expect(progression.entries).toEqual([]);
+
+		progression.suspended = false;
+		expect(recordChord("C")).toBe(0);
+	});
+
+	it("returns the new entry's index and lets beats be set on release", () => {
+		const index = recordChord("C", [60, 64, 67]);
+		expect(index).toBe(0);
+		setEntryBeats(index, 4);
+		expect(progression.entries[0]).toEqual({
+			kind: "chord",
+			label: "C",
+			notes: [60, 64, 67],
+			beats: 4,
+		});
+		expect(stored()[0].beats).toBe(4);
+	});
+
+	it("ignores setEntryBeats for missing or break entries", () => {
+		recordChord("C");
+		addLineBreak();
+		expect(() => setEntryBeats(1, 2)).not.toThrow(); // break
+		expect(() => setEntryBeats(99, 2)).not.toThrow(); // missing
+		expect(progression.entries[1]).toEqual({ kind: "break" });
 	});
 
 	it("records chords in order", () => {
@@ -46,9 +78,9 @@ describe("progression store", () => {
 		recordChord("Am");
 		recordChord("F7");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
-			{ kind: "chord", label: "Am", notes: [] },
-			{ kind: "chord", label: "F7", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
+			{ kind: "chord", label: "Am", notes: [], beats: 1 },
+			{ kind: "chord", label: "F7", notes: [], beats: 1 },
 		]);
 	});
 
@@ -61,9 +93,9 @@ describe("progression store", () => {
 		addLineBreak(); // doubled — ignored
 		recordChord("G");
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
 			{ kind: "break" },
-			{ kind: "chord", label: "G", notes: [] },
+			{ kind: "chord", label: "G", notes: [], beats: 1 },
 		]);
 	});
 
@@ -72,7 +104,7 @@ describe("progression store", () => {
 		recordChord("G");
 		deleteLast();
 		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
 		]);
 		deleteLast();
 		deleteLast(); // empty — no throw
@@ -90,12 +122,14 @@ describe("progression store", () => {
 
 	it("persists every mutation to localStorage", () => {
 		recordChord("C");
-		expect(stored()).toEqual([{ kind: "chord", label: "C", notes: [] }]);
+		expect(stored()).toEqual([
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
+		]);
 		addLineBreak();
 		recordChord("G");
 		deleteLast();
 		expect(stored()).toEqual([
-			{ kind: "chord", label: "C", notes: [] },
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
 			{ kind: "break" },
 		]);
 	});

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -1,18 +1,21 @@
 // Progression pad store - captures played chords as a jotted progression,
 // persisted to localStorage so a work-in-progress survives reloads.
 
+import type { ChordBeats } from "$utils/rhythm";
+
 export type ProgressionEntry =
-	| { kind: "chord"; label: string; notes: number[] }
+	| { kind: "chord"; label: string; notes: number[]; beats: ChordBeats }
 	| { kind: "break" };
 
 // v2: chord entries carry MIDI note numbers (for playback and .mid export).
 // The key was bumped from "fifths-progression", intentionally abandoning
-// note-less v1 jottings.
+// note-less v1 jottings. `beats` was added later and defaults to 1 when
+// missing, so v2 data upgrades in place.
 const STORAGE_KEY = "fifths-progression-v2";
 
 function isValidEntry(entry: unknown): entry is ProgressionEntry {
 	if (typeof entry !== "object" || entry === null) return false;
-	const candidate = entry as Partial<ProgressionEntry>;
+	const candidate = entry as Partial<ProgressionEntry> & { beats?: unknown };
 	if (candidate.kind === "break") return true;
 	return (
 		candidate.kind === "chord" &&
@@ -20,6 +23,10 @@ function isValidEntry(entry: unknown): entry is ProgressionEntry {
 		Array.isArray(candidate.notes) &&
 		candidate.notes.every((note) => typeof note === "number")
 	);
+}
+
+function normalizeBeats(value: unknown): ChordBeats {
+	return value === 2 || value === 4 ? value : 1;
 }
 
 // Guarded for SSR/prerender, where localStorage does not exist
@@ -30,7 +37,13 @@ function loadEntries(): ProgressionEntry[] {
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		if (!Array.isArray(parsed)) return [];
-		return parsed.filter(isValidEntry);
+		return parsed
+			.filter(isValidEntry)
+			.map((entry: ProgressionEntry) =>
+				entry.kind === "chord"
+					? { ...entry, beats: normalizeBeats(entry.beats) }
+					: entry,
+			);
 	} catch {
 		return [];
 	}
@@ -48,21 +61,42 @@ function persist(): void {
 
 export const progression = $state({
 	entries: loadEntries(),
-	// While paused, played chords are not jotted (session-only, not persisted)
-	paused: false,
+	// The ● rec toggle: off = noodle freely without jotting (session-only)
+	recording: true,
+	// Set by the transport while playback runs: live jotting is suspended so
+	// playing along with playback cannot jot into the progression being
+	// played. Cleared when playback ends — which is what makes "press play,
+	// listen to the end, keep playing" a natural punch-in.
+	suspended: false,
 });
+
+// True when a played chord should be jotted right now
+function shouldRecord(): boolean {
+	return progression.recording && !progression.suspended;
+}
 
 // Append a played chord (called by the Instrument on each distinct chord).
 // `notes` are MIDI note numbers, used for pad playback and .mid export.
-export function recordChord(label: string, notes: number[] = []): void {
-	if (progression.paused) return;
-	progression.entries.push({ kind: "chord", label, notes });
+// Returns the entry's index so the caller can set its beats on release,
+// or -1 when not recording.
+export function recordChord(label: string, notes: number[] = []): number {
+	if (!shouldRecord()) return -1;
+	progression.entries.push({ kind: "chord", label, notes, beats: 1 });
+	persist();
+	return progression.entries.length - 1;
+}
+
+// Set a chord's duration once its hold length is known (on release/slide)
+export function setEntryBeats(index: number, beats: ChordBeats): void {
+	const entry = progression.entries[index];
+	if (!entry || entry.kind !== "chord") return;
+	entry.beats = beats;
 	persist();
 }
 
-// Pause/resume jotting
-export function togglePaused(): void {
-	progression.paused = !progression.paused;
+// The ● rec toggle
+export function toggleRecording(): void {
+	progression.recording = !progression.recording;
 }
 
 // Start a new line in the jotted progression

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -13,14 +13,19 @@ import {
 	clearProgression,
 	progression,
 	recordChord,
+	setEntryBeats,
 } from "$stores/progression.svelte";
 import {
+	pausePlayback,
 	player,
 	playProgression,
+	setBpm,
 	stopPlayback,
+	toggleLoop,
 } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
+// One beat at the default 120 BPM
 const STEP_MS = 500;
 const C_NOTES = [60, 64, 67];
 const G_NOTES = [55, 59, 62];
@@ -31,9 +36,12 @@ describe("progression player", () => {
 		// Reset player state BEFORE clearing mocks — stopPlayback itself
 		// calls the mocked stopChordById
 		stopPlayback();
+		player.loop = false;
+		setBpm(120);
 		vi.clearAllMocks();
 		clearProgression();
-		progression.paused = false;
+		progression.recording = true;
+		progression.suspended = false;
 		settings.activeVoice = "sine";
 	});
 
@@ -61,13 +69,93 @@ describe("progression player", () => {
 		expect(startChord).toHaveBeenCalledTimes(2);
 	});
 
-	it("releases each chord before the next step", () => {
+	it("suspends live jotting while the transport is engaged (punch-in)", () => {
 		recordChord("C", C_NOTES);
 		playProgression();
-		expect(stopChordById).not.toHaveBeenCalledWith(-1);
 
-		vi.advanceTimersByTime(STEP_MS - 1);
+		// While playing, jotting is suspended — playing along cannot jot
+		expect(progression.suspended).toBe(true);
+		expect(recordChord("G", G_NOTES)).toBe(-1);
+		expect(progression.entries).toHaveLength(1);
+
+		// Natural end lifts the suspension: the next chord played appends
+		vi.advanceTimersByTime(STEP_MS);
+		expect(player.playing).toBe(false);
+		expect(progression.suspended).toBe(false);
+		expect(recordChord("G", G_NOTES)).toBe(1);
+	});
+
+	it("honors each chord's beats at the current tempo", () => {
+		recordChord("C", C_NOTES);
+		setEntryBeats(0, 2);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		// C holds for 2 beats — still sounding after one step
+		vi.advanceTimersByTime(STEP_MS);
+		expect(player.position).toBe(0);
+		vi.advanceTimersByTime(STEP_MS);
+		expect(player.position).toBe(1);
+	});
+
+	it("scales step time with BPM", () => {
+		setBpm(60); // 1000ms per beat
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		vi.advanceTimersByTime(500);
+		expect(player.position).toBe(0); // not yet
+		vi.advanceTimersByTime(500);
+		expect(player.position).toBe(1);
+	});
+
+	it("clamps and persists the tempo", () => {
+		setBpm(999);
+		expect(player.bpm).toBe(240);
+		setBpm(10);
+		expect(player.bpm).toBe(40);
+		setBpm(96);
+		expect(localStorage.getItem("fifths-progression-bpm")).toBe("96");
+	});
+
+	it("pauses at the current position and resumes from it", () => {
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		recordChord("Am", [57, 60, 64]);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS); // now on G (index 1)
+
+		pausePlayback();
+		expect(player.playing).toBe(true);
+		expect(player.paused).toBe(true);
+		expect(player.position).toBe(1);
 		expect(stopChordById).toHaveBeenCalledWith(-1);
+		expect(progression.suspended).toBe(true); // still engaged
+
+		const callsBefore = vi.mocked(startChord).mock.calls.length;
+		vi.advanceTimersByTime(STEP_MS * 4);
+		expect(vi.mocked(startChord).mock.calls.length).toBe(callsBefore); // frozen
+
+		playProgression(); // resume
+		expect(player.paused).toBe(false);
+		expect(player.position).toBe(1); // replays the paused chord
+		expect(vi.mocked(startChord).mock.calls.length).toBe(callsBefore + 1);
+	});
+
+	it("loops back to the top when loop is on", () => {
+		recordChord("C", C_NOTES);
+		recordChord("G", G_NOTES);
+		toggleLoop();
+		playProgression();
+
+		vi.advanceTimersByTime(STEP_MS * 2); // past the end
+		expect(player.playing).toBe(true);
+		expect(player.position).toBe(0); // wrapped
+		expect(progression.suspended).toBe(true); // loop never punches in
+
+		stopPlayback();
+		expect(progression.suspended).toBe(false);
 	});
 
 	it("rests on line breaks", () => {
@@ -84,13 +172,12 @@ describe("progression player", () => {
 		expect(startChord).toHaveBeenCalledTimes(2);
 	});
 
-	it("stops at the end and resets position", () => {
+	it("releases each chord before the next step", () => {
 		recordChord("C", C_NOTES);
 		playProgression();
-		vi.advanceTimersByTime(STEP_MS);
+		expect(stopChordById).not.toHaveBeenCalledWith(-1);
 
-		expect(player.playing).toBe(false);
-		expect(player.position).toBe(-1);
+		vi.advanceTimersByTime(STEP_MS - 1);
 		expect(stopChordById).toHaveBeenCalledWith(-1);
 	});
 

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -1,26 +1,60 @@
 // Plays the jotted progression back through the app's own synth. Playback
 // goes straight to the audio store with a reserved pointer ID, bypassing the
-// Instrument's jotting path — so playback never re-records itself.
+// Instrument's jotting path — and while the transport is engaged, live
+// jotting is suspended (progression.suspended) so playing along cannot jot
+// into the progression being played. When playback reaches its natural end,
+// the suspension lifts and — with ● rec on — the next chord played appends:
+// a DAW-style punch-in.
 
 import { startChord, stopChordById } from "$stores/audio.svelte";
 import { progression } from "$stores/progression.svelte";
 import { settings } from "$stores/settings.svelte";
 
 import { midiToFrequency } from "$utils/midi";
+import { beatMs } from "$utils/rhythm";
 
 // Reserved pointer ID for programmatic playback (never a real pointer)
 const PLAYBACK_POINTER_ID = -1;
 
-// Uniform step timing until the transport (Phase B) brings a real BPM:
-// 120 BPM quarter notes, with a short release before the next chord
-const STEP_MS = 500;
-const RELEASE_MS = 420;
+// Fraction of a step held before release, for articulation between chords
+const GATE = 0.85;
+
+const BPM_STORAGE_KEY = "fifths-progression-bpm";
+const DEFAULT_BPM = 120;
+const MIN_BPM = 40;
+const MAX_BPM = 240;
+
+function loadBpm(): number {
+	if (typeof localStorage === "undefined") return DEFAULT_BPM;
+	const stored = Number(localStorage.getItem(BPM_STORAGE_KEY));
+	return Number.isFinite(stored) && stored >= MIN_BPM && stored <= MAX_BPM
+		? stored
+		: DEFAULT_BPM;
+}
 
 export const player = $state({
 	playing: false,
+	paused: false,
+	loop: false,
+	bpm: loadBpm(),
 	// Index into progression.entries of the sounding chord, -1 when idle
 	position: -1,
 });
+
+export function setBpm(bpm: number): void {
+	player.bpm = Math.max(MIN_BPM, Math.min(MAX_BPM, Math.round(bpm)));
+	if (typeof localStorage !== "undefined") {
+		try {
+			localStorage.setItem(BPM_STORAGE_KEY, String(player.bpm));
+		} catch {
+			// Session-only tempo is fine
+		}
+	}
+}
+
+export function toggleLoop(): void {
+	player.loop = !player.loop;
+}
 
 let stepTimeout: ReturnType<typeof setTimeout> | null = null;
 let releaseTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -32,15 +66,25 @@ function clearTimers(): void {
 	releaseTimeout = null;
 }
 
+function entryBeats(entry: (typeof progression.entries)[number]): number {
+	return entry.kind === "chord" ? entry.beats : 1; // breaks rest one beat
+}
+
 function step(index: number): void {
 	// Entries can shrink mid-playback (undo/clear) — re-check every step
-	if (!player.playing || index >= progression.entries.length) {
+	if (!player.playing) return;
+	if (index >= progression.entries.length) {
+		if (player.loop && progression.entries.length > 0) {
+			step(0);
+			return;
+		}
 		stopPlayback();
 		return;
 	}
 
 	const entry = progression.entries[index];
 	player.position = index;
+	const durationMs = entryBeats(entry) * beatMs(player.bpm);
 
 	if (entry.kind === "chord" && entry.notes.length > 0) {
 		startChord(
@@ -50,23 +94,41 @@ function step(index: number): void {
 		);
 		releaseTimeout = setTimeout(() => {
 			stopChordById(PLAYBACK_POINTER_ID);
-		}, RELEASE_MS);
+		}, durationMs * GATE);
 	}
-	// Breaks (and legacy note-less chords) simply rest for a step
+	// Breaks (and legacy note-less chords) simply rest for their duration
 
-	stepTimeout = setTimeout(() => step(index + 1), STEP_MS);
+	stepTimeout = setTimeout(() => step(index + 1), durationMs);
 }
 
 export function playProgression(): void {
-	if (player.playing) return;
+	if (player.playing && !player.paused) return;
 	if (progression.entries.length === 0) return;
+
+	// Resume from a pause, or start from the top
+	const startIndex =
+		player.paused && player.position >= 0 ? player.position : 0;
 	player.playing = true;
-	step(0);
+	player.paused = false;
+	progression.suspended = true;
+	step(startIndex);
+}
+
+// True pause: freezes the transport at the current position. Jotting stays
+// suspended — the transport is still engaged.
+export function pausePlayback(): void {
+	if (!player.playing || player.paused) return;
+	clearTimers();
+	stopChordById(PLAYBACK_POINTER_ID);
+	player.paused = true;
 }
 
 export function stopPlayback(): void {
 	clearTimers();
 	stopChordById(PLAYBACK_POINTER_ID);
 	player.playing = false;
+	player.paused = false;
 	player.position = -1;
+	// Transport disengaged: live jotting may resume (punch-in moment)
+	progression.suspended = false;
 }

--- a/src/lib/utils/midi.test.ts
+++ b/src/lib/utils/midi.test.ts
@@ -52,6 +52,7 @@ describe("progressionToMidi", () => {
 		kind: "chord",
 		label: "C",
 		notes: C_MAJOR_NOTES,
+		beats: 1,
 	};
 	const lineBreak: ProgressionEntry = { kind: "break" };
 
@@ -92,7 +93,9 @@ describe("progressionToMidi", () => {
 	});
 
 	it("holds each chord for one quarter note", () => {
-		const bytes = bytesOf([{ kind: "chord", label: "A", notes: [69] }]);
+		const bytes = bytesOf([
+			{ kind: "chord", label: "A", notes: [69], beats: 1 },
+		]);
 		// After the tempo event: delta 0, note-on 69; delta 480, note-off 69
 		expect(bytes.slice(29)).toEqual([
 			0x00,
@@ -111,6 +114,16 @@ describe("progressionToMidi", () => {
 		]);
 	});
 
+	it("holds multi-beat chords proportionally longer", () => {
+		const bytes = bytesOf([
+			{ kind: "chord", label: "A", notes: [69], beats: 2 },
+		]);
+		// Note-off delta is 2 quarters = 960 ticks = VLQ 0x87 0x40
+		expect(bytes.slice(29)).toEqual([
+			0x00, 0x90, 69, 96, 0x87, 0x40, 0x80, 69, 0, 0x00, 0xff, 0x2f, 0x00,
+		]);
+	});
+
 	it("turns line breaks into one-quarter rests before the next chord", () => {
 		const single = bytesOf([cChord, cChord]);
 		const withBreak = bytesOf([cChord, lineBreak, cChord]);
@@ -124,7 +137,7 @@ describe("progressionToMidi", () => {
 	});
 
 	it("skips legacy chords without note data", () => {
-		const bytes = bytesOf([{ kind: "chord", label: "C", notes: [] }]);
+		const bytes = bytesOf([{ kind: "chord", label: "C", notes: [], beats: 1 }]);
 		expect(bytes.filter((b) => b === 0x90)).toHaveLength(0);
 	});
 

--- a/src/lib/utils/midi.ts
+++ b/src/lib/utils/midi.ts
@@ -56,8 +56,8 @@ function uint16(value: number): number[] {
 
 /**
  * Build a format-0 .mid file from progression entries.
- * Each chord lasts one quarter note; line breaks become one-quarter rests.
- * Entries without note data (legacy jottings) are skipped.
+ * Each chord lasts its recorded `beats` in quarter notes; line breaks become
+ * one-quarter rests. Entries without note data (legacy jottings) are skipped.
  */
 export function progressionToMidi(
 	entries: ProgressionEntry[],
@@ -96,10 +96,11 @@ export function progressionToMidi(
 				NOTE_VELOCITY,
 			);
 		});
-		// Note-offs one quarter note later
+		// Note-offs after the chord's recorded duration
+		const durationTicks = entry.beats * TICKS_PER_QUARTER;
 		entry.notes.forEach((note, i) => {
 			events.push(
-				...encodeVariableLength(i === 0 ? TICKS_PER_QUARTER : 0),
+				...encodeVariableLength(i === 0 ? durationTicks : 0),
 				0x80,
 				note & 0x7f,
 				0x00,

--- a/src/lib/utils/rhythm.test.ts
+++ b/src/lib/utils/rhythm.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { beatMs, beatsFromHold } from "./rhythm";
+
+describe("beatMs", () => {
+	it("converts BPM to milliseconds per beat", () => {
+		expect(beatMs(120)).toBe(500);
+		expect(beatMs(60)).toBe(1000);
+		expect(beatMs(240)).toBe(250);
+	});
+});
+
+describe("beatsFromHold", () => {
+	// At 120 BPM one beat is 500ms
+	it("reads short holds as one-beat stabs", () => {
+		expect(beatsFromHold(80, 120)).toBe(1); // a tap
+		expect(beatsFromHold(500, 120)).toBe(1);
+		expect(beatsFromHold(740, 120)).toBe(1); // just under 1.5 beats
+	});
+
+	it("reads medium holds as half notes", () => {
+		expect(beatsFromHold(750, 120)).toBe(2); // 1.5 beats
+		expect(beatsFromHold(1000, 120)).toBe(2);
+		expect(beatsFromHold(1490, 120)).toBe(2); // just under 3 beats
+	});
+
+	it("reads long holds as whole notes", () => {
+		expect(beatsFromHold(1500, 120)).toBe(4); // 3 beats
+		expect(beatsFromHold(4000, 120)).toBe(4);
+	});
+
+	it("scales with tempo", () => {
+		// 1000ms is one beat at 60 BPM (stab) but four beats at 240 BPM
+		expect(beatsFromHold(1000, 60)).toBe(1);
+		expect(beatsFromHold(1000, 240)).toBe(4);
+	});
+});

--- a/src/lib/utils/rhythm.ts
+++ b/src/lib/utils/rhythm.ts
@@ -1,0 +1,27 @@
+/**
+ * Rhythm helpers for the progression pad.
+ *
+ * Chord rhythm is derived from how long the player HELD each chord
+ * (press → release), not from the gaps between chords — gaps while jotting
+ * are mostly thinking time, not musical rests. Held time is quantized to a
+ * clean grid of 1, 2, or 4 beats at the pad's BPM.
+ */
+
+export type ChordBeats = 1 | 2 | 4;
+
+/** Milliseconds per beat at a given tempo */
+export function beatMs(bpm: number): number {
+	return 60_000 / bpm;
+}
+
+/**
+ * Quantize a held duration to 1, 2, or 4 beats.
+ * Anything under 1.5 beats reads as a one-beat stab; under 3 beats as a
+ * half-note hold; longer holds get a full bar (in 4/4).
+ */
+export function beatsFromHold(heldMs: number, bpm: number): ChordBeats {
+	const beats = heldMs / beatMs(bpm);
+	if (beats < 1.5) return 1;
+	if (beats < 3) return 2;
+	return 4;
+}


### PR DESCRIPTION
## Summary

UI/UX rework of the progression pad based on real use:

**Transport & recorder split** — pause next to play now IS a playback pause:
- **play/pause** toggle (true pause: position kept, resume from the same chord), **stop**, and a **loop** toggle
- **● rec** toggle for jotting (off = noodle freely without recording)

**Punch-in continuation** — while the transport runs, live jotting is suspended so playing along can't jot into the progression being played. When playback reaches its natural end with rec on, the suspension lifts and your next chord appends: *press play, listen to the end, keep playing*. A loop never reaches a natural end, so practice loops never punch in.

**Tempo & rhythm** —
- **BPM** control on the pad (40–240, persisted) drives playback and MIDI export tempo
- Chord rhythm now derives from **hold duration** (press→release, quantized to 1/2/4 beats) rather than an invented uniform grid — gaps between chords are thinking time and are deliberately ignored. Playback and .mid export reproduce your long/short chords on a clean grid.

## Test plan
- [x] 264 tests passing (+18): quantization thresholds, pause/resume/loop, suspension + punch-in re-arm, per-beat timing, BPM clamp/persist, multi-beat MIDI deltas, hold-to-beats via the Instrument
- [x] svelte-check, biome, build clean
- [ ] Manual: hold chords long/short → play back → rhythm reflects the holds; play → pause → resume; loop a progression; punch in after playback ends; export and check durations in a DAW