### PR TITLE
chore: hide the export midi button (v0.10.1)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -32,7 +32,13 @@
 		"svelte-check",
 		"uno.css"
 	],
-	"ignoreExports": [{ "file": "src/hooks.server.ts", "exports": ["config"] }],
+	"ignoreExports": [
+		{ "file": "src/hooks.server.ts", "exports": ["config"] },
+		{
+			"file": "src/lib/utils/midi.ts",
+			"exports": ["progressionToMidi", "encodeVariableLength"]
+		}
+	],
 	"ignoreExportsUsedInFile": true,
 	"ignorePatterns": [
 		".svelte-kit/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-07-12
+
+### Removed
+- The "export midi" button — small use case for now, and it cluttered the pad. The tested .mid writer stays in the codebase (`$utils/midi`) for a future, less prominent surface (e.g. an overflow menu or the Web MIDI epic).
+
 ## [0.10.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.10.0
+**Current Version**: 0.10.1
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -6,9 +6,10 @@ Progression pad
 - Transport: play/pause (true pause, position kept), stop, loop; while the
   transport is engaged, live jotting is suspended — when playback ends
   naturally with rec on, the next chord played appends (punch-in)
-- ● rec toggles jotting; export midi downloads a .mid at the pad's BPM
+- ● rec toggles jotting
 - Line break / undo / clear; the X hides the pad (re-enable from settings);
   content persists in localStorage; hidden until the first chord is played
+- (.mid export exists in $utils/midi but is not surfaced in the UI for now)
 -->
 
 <script lang="ts">
@@ -28,8 +29,6 @@ import {
 	toggleLoop,
 } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
-
-import { progressionToMidi } from "$utils/midi";
 
 // Group flat entries into visual lines at each break, keeping each chord's
 // index into progression.entries so the sounding chord can be highlighted
@@ -55,17 +54,6 @@ const transportRunning = $derived(player.playing && !player.paused);
 
 function dismiss() {
 	settings.showProgressionPad = false;
-}
-
-function exportMidi() {
-	const bytes = progressionToMidi(progression.entries, player.bpm);
-	const blob = new Blob([bytes], { type: "audio/midi" });
-	const url = URL.createObjectURL(blob);
-	const anchor = document.createElement("a");
-	anchor.href = url;
-	anchor.download = "progression.mid";
-	anchor.click();
-	URL.revokeObjectURL(url);
 }
 
 // Silence playback if the pad unmounts (dismissed / mode change)
@@ -180,15 +168,6 @@ const activeClasses = "text-accent border-accent/60";
 			</button>
 			<button type="button" class={buttonClasses} onclick={clearProgression}>
 				clear
-			</button>
-			<button
-				type="button"
-				class={buttonClasses}
-				disabled={!hasPlayableEntries}
-				title="Download this progression as a .mid file at the current BPM"
-				onclick={exportMidi}
-			>
-				export midi
 			</button>
 		</div>
 	</div>

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -13,7 +13,7 @@ import { settings } from "$stores/settings.svelte";
 
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("ProgressionPad", () => {
 	beforeEach(() => {
@@ -134,42 +134,18 @@ describe("ProgressionPad", () => {
 		expect(progression.entries).toHaveLength(1);
 	});
 
-	it("disables play and export when no entry has note data", () => {
+	it("disables play when no entry has note data", () => {
 		recordChord("C"); // legacy-style, no notes
 		render(ProgressionPad);
 		expect(screen.getByRole("button", { name: "play" })).toBeDisabled();
-		expect(screen.getByRole("button", { name: "export midi" })).toBeDisabled();
 	});
 
-	it("exports the progression as a .mid download", async () => {
-		const user = userEvent.setup();
+	it("does not surface a midi export button (hidden for now)", () => {
 		recordChord("C", [60, 64, 67]);
 		render(ProgressionPad);
-
-		const exported: Blob[] = [];
-		const createObjectURL = vi.fn((blob: Blob) => {
-			exported.push(blob);
-			return "blob:fake";
-		});
-		vi.stubGlobal("URL", {
-			...URL,
-			createObjectURL,
-			revokeObjectURL: vi.fn(),
-		});
-		const click = vi
-			.spyOn(HTMLAnchorElement.prototype, "click")
-			.mockImplementation(() => {});
-
-		await user.click(screen.getByRole("button", { name: "export midi" }));
-
-		expect(createObjectURL).toHaveBeenCalledTimes(1);
-		expect(exported).toHaveLength(1);
-		const bytes = new Uint8Array(await exported[0].arrayBuffer());
-		// "MThd" — a Standard MIDI File header
-		expect(Array.from(bytes.slice(0, 4))).toEqual([0x4d, 0x54, 0x68, 0x64]);
-
-		click.mockRestore();
-		vi.unstubAllGlobals();
+		expect(
+			screen.queryByRole("button", { name: "export midi" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("wires the new line, undo, and clear controls", async () => {

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -168,5 +168,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.10.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.10.1</div>
 </div>

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -89,7 +89,7 @@ export function recordChord(label: string, notes: number[] = []): number {
 // Set a chord's duration once its hold length is known (on release/slide)
 export function setEntryBeats(index: number, beats: ChordBeats): void {
 	const entry = progression.entries[index];
-	if (!entry || entry.kind !== "chord") return;
+	if (entry?.kind !== "chord") return;
 	entry.beats = beats;
 	persist();
 }


### PR DESCRIPTION
Removes the **export midi** button from the pad — small use case for now, and it cluttered the UI. The fully-tested SMF writer stays in `$utils/midi` (fallow ignoreExports documents the retention) for a future, less prominent surface. A test pins that the button is not rendered. 264 tests passing.