### PR TITLE
feat: metronome click and tap tempo (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-07-12
+
+### Added
+- Metronome: a **click** toggle in the toolbar — 4/4 with an accented downbeat, scheduled ahead on the AudioContext clock (drift-free lookahead pattern), routed dry so the click stays crisp regardless of reverb
+- **Tap tempo**: tap the new toolbar button in time to set the BPM (averages recent taps; a 2s pause starts fresh)
+- Tempo controls (bpm / tap / click) live in the toolbar and share one tempo: the click, progression playback, hold-duration quantization, and MIDI export all follow it; tempo changes retune a running click live
+
+### Changed
+- The BPM input moved from the progression pad to the toolbar tempo controls
+
 ## [0.10.1] - 2026-07-12
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.10.1
+**Current Version**: 0.11.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -60,12 +60,12 @@ insert node + a settings slider), so each is a small standalone ship:
 
 ### Phase B — rhythm infrastructure
 
-**B1. Metronome / click** — effort: S–M
-- Builds the **transport**: BPM setting, play/stop, and a lookahead scheduler
-  (the standard ~25ms `setInterval` scheduling beats ~100ms ahead on the
-  AudioContext clock — required for drift-free timing)
-- Click = short oscillator blip, accented downbeat, time signature 4/4 first
-- Toolbar toggle + BPM control; transport lives in a new store
+**B1. Metronome / click** — ✅ shipped in v0.11.0 (+ tap tempo)
+- Lookahead scheduler (~25ms `setInterval` booking clicks ~100ms ahead on the
+  AudioContext clock — drift-free), 4/4 with accented downbeat, dry signal
+  path (bypasses reverb)
+- Toolbar tempo controls: bpm input / tap tempo / click toggle — one shared
+  tempo (player.bpm) drives the click, pad playback, and MIDI export
 
 **B2. Simple drum machine** — effort: M–L (depends on B1)
 - Synthesized kit, no samples: kick (sine pitch-drop), snare (noise burst +

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.10.1",
+	"version": "0.11.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -24,7 +24,6 @@ import {
 	pausePlayback,
 	player,
 	playProgression,
-	setBpm,
 	stopPlayback,
 	toggleLoop,
 } from "$stores/progressionPlayer.svelte";
@@ -142,21 +141,6 @@ const activeClasses = "text-accent border-accent/60";
 			>
 				&#9679; rec
 			</button>
-
-			<!-- tempo -->
-			<label class="flex items-center gap-1 text-xs opacity-80">
-				<input
-					type="number"
-					min="40"
-					max="240"
-					value={player.bpm}
-					onchange={(e) =>
-						setBpm(Number.parseInt(e.currentTarget.value, 10) || 120)}
-					class="w-14 rounded border border-neutral-100/30 bg-primary/20 px-1.5 py-1 text-xs tabular-nums"
-					aria-label="Tempo in beats per minute"
-				/>
-				bpm
-			</label>
 		</div>
 
 		<div class="flex flex-wrap gap-2">

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -11,7 +11,7 @@ import {
 import { player, setBpm, stopPlayback } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
-import { fireEvent, render, screen } from "@testing-library/svelte";
+import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -105,20 +105,12 @@ describe("ProgressionPad", () => {
 		expect(player.loop).toBe(true);
 	});
 
-	it("sets the tempo from the bpm input, clamped to range", async () => {
+	it("no longer hosts the tempo input (moved to the toolbar)", () => {
 		recordChord("C", [60, 64, 67]);
 		render(ProgressionPad);
-
-		const bpm = screen.getByLabelText(
-			"Tempo in beats per minute",
-		) as HTMLInputElement;
-		expect(bpm).toHaveValue(120);
-
-		await fireEvent.change(bpm, { target: { value: "90" } });
-		expect(player.bpm).toBe(90);
-
-		await fireEvent.change(bpm, { target: { value: "999" } });
-		expect(player.bpm).toBe(240);
+		expect(
+			screen.queryByLabelText("Tempo in beats per minute"),
+		).not.toBeInTheDocument();
 	});
 
 	it("dismisses the pad via the X (re-enabled from settings)", async () => {

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -168,5 +168,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.10.1</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.11.0</div>
 </div>

--- a/src/lib/components/TempoControls.svelte
+++ b/src/lib/components/TempoControls.svelte
@@ -1,0 +1,50 @@
+<!--
+@component
+Tempo controls (toolbar)
+- One shared tempo for everything: the bpm input, tap tempo, the metronome
+  click, progression playback, and MIDI export all read/write player.bpm
+- click toggles a 4/4 metronome with an accented downbeat
+-->
+
+<script lang="ts">
+import { metronome, toggleMetronome } from "$stores/metronome.svelte";
+import { player, setBpm, tapTempo } from "$stores/progressionPlayer.svelte";
+
+const buttonClasses =
+	"rounded border border-neutral-100/30 px-2 py-1 text-xs opacity-80 hover:opacity-100 hover:border-neutral-100/60";
+</script>
+
+<div data-tempo-controls class="flex items-center gap-2">
+	<label class="flex items-center gap-1 text-xs opacity-80">
+		<input
+			type="number"
+			min="40"
+			max="240"
+			value={player.bpm}
+			onchange={(e) =>
+				setBpm(Number.parseInt(e.currentTarget.value, 10) || 120)}
+			class="w-14 rounded border border-neutral-100/30 bg-primary/20 px-1.5 py-1 text-xs tabular-nums"
+			aria-label="Tempo in beats per minute"
+		/>
+		bpm
+	</label>
+	<button
+		type="button"
+		class={buttonClasses}
+		title="Tap in time to set the tempo"
+		onclick={tapTempo}
+	>
+		tap
+	</button>
+	<button
+		type="button"
+		class="{buttonClasses} {metronome.running
+			? 'text-accent border-accent/60'
+			: ''}"
+		aria-pressed={metronome.running}
+		title={metronome.running ? "Stop the click" : "Start the click (4/4)"}
+		onclick={toggleMetronome}
+	>
+		click
+	</button>
+</div>

--- a/src/lib/components/TempoControls.svelte.test.ts
+++ b/src/lib/components/TempoControls.svelte.test.ts
@@ -1,0 +1,70 @@
+// Component tests for the toolbar tempo controls (bpm / tap / click).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$stores/audio.svelte", () => ({
+	audioTime: vi.fn(() => Date.now() / 1000),
+	scheduleClick: vi.fn(),
+	unlockAudio: vi.fn(),
+	startChord: vi.fn(),
+	stopChordById: vi.fn(),
+}));
+
+import TempoControls from "$components/TempoControls.svelte";
+
+import { metronome, stopMetronome } from "$stores/metronome.svelte";
+import { player, setBpm } from "$stores/progressionPlayer.svelte";
+
+import { fireEvent, render, screen } from "@testing-library/svelte";
+
+describe("TempoControls", () => {
+	beforeEach(() => {
+		stopMetronome();
+		setBpm(120);
+	});
+
+	afterEach(() => {
+		stopMetronome();
+	});
+
+	it("sets the tempo from the bpm input, clamped to range", async () => {
+		render(TempoControls);
+		const bpm = screen.getByLabelText(
+			"Tempo in beats per minute",
+		) as HTMLInputElement;
+		expect(bpm).toHaveValue(120);
+
+		await fireEvent.change(bpm, { target: { value: "90" } });
+		expect(player.bpm).toBe(90);
+
+		await fireEvent.change(bpm, { target: { value: "999" } });
+		expect(player.bpm).toBe(240);
+	});
+
+	it("sets the tempo from tapped intervals", async () => {
+		vi.useFakeTimers();
+		render(TempoControls);
+		const tap = screen.getByRole("button", { name: "tap" });
+
+		// Four taps 500ms apart = 120 BPM... tapped at 600ms = 100 BPM
+		for (let i = 0; i < 4; i++) {
+			await fireEvent.click(tap);
+			vi.advanceTimersByTime(600);
+		}
+		expect(player.bpm).toBe(100);
+		vi.useRealTimers();
+	});
+
+	it("toggles the click", async () => {
+		render(TempoControls);
+		const click = screen.getByRole("button", { name: "click" });
+		expect(click).toHaveAttribute("aria-pressed", "false");
+
+		await fireEvent.click(click);
+		expect(metronome.running).toBe(true);
+		expect(click).toHaveAttribute("aria-pressed", "true");
+
+		await fireEvent.click(click);
+		expect(metronome.running).toBe(false);
+	});
+});

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -504,6 +504,49 @@ describe("audio store", () => {
 		});
 	});
 
+	describe("metronome click scheduling", () => {
+		it("audioTime is null before init and the context clock after", async () => {
+			const audio = await freshStore();
+			expect(audio.audioTime()).toBeNull();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			expect(audio.audioTime()).toBe(0);
+		});
+
+		it("scheduleClick books a short dry blip at the exact time", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			const ctx = FakeAudioContext.instances[0];
+			const oscillatorsBefore = ctx.createdOscillators.length;
+
+			audio.scheduleClick(1.5, true);
+
+			const osc = ctx.createdOscillators[oscillatorsBefore];
+			expect(osc.type).toBe("square");
+			expect(osc.frequency.setValueAtTime).toHaveBeenCalledWith(1600, 1.5);
+			expect(osc.start).toHaveBeenCalledWith(1.5);
+			expect(osc.stop).toHaveBeenCalledWith(1.56);
+			// Dry path: the click gain connects straight to the destination
+			const clickGain = ctx.createdGains.at(-1);
+			expect(clickGain?.connect).toHaveBeenCalledWith(ctx.destination);
+		});
+
+		it("unaccented clicks use the lower pitch", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			const ctx = FakeAudioContext.instances[0];
+
+			audio.scheduleClick(2, false);
+			const osc = ctx.createdOscillators.at(-1);
+			expect(osc?.frequency.setValueAtTime).toHaveBeenCalledWith(1100, 2);
+		});
+
+		it("is a no-op before the context exists", async () => {
+			const audio = await freshStore();
+			expect(() => audio.scheduleClick(0, true)).not.toThrow();
+			expect(FakeAudioContext.instances).toHaveLength(0);
+		});
+	});
+
 	describe("toggleReverb", () => {
 		it("turns reverb off and restores the last audible mix on the next toggle", async () => {
 			const audio = await freshStore();

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -144,6 +144,37 @@ export function toggleReverb(): void {
 	setReverbMix(audioState.reverbMix > 0 ? 0 : lastAudibleReverbMix);
 }
 
+// The AudioContext clock, for scheduling ahead (metronome); null before init
+export function audioTime(): number | null {
+	return audioContext ? audioContext.currentTime : null;
+}
+
+// Schedule a short metronome click at an exact context time. Clicks connect
+// straight to the destination (not through the master chain) so they stay
+// dry — a reverberant click defeats the purpose — scaled by master volume.
+export function scheduleClick(atTime: number, accent = false): void {
+	if (!audioContext) return;
+
+	const osc = audioContext.createOscillator();
+	const gain = audioContext.createGain();
+	osc.type = "square";
+	osc.frequency.setValueAtTime(accent ? 1600 : 1100, atTime);
+
+	const peak = 0.25 * audioState.masterVolume * (accent ? 1.4 : 1);
+	gain.gain.setValueAtTime(0, atTime);
+	gain.gain.linearRampToValueAtTime(peak, atTime + 0.002);
+	gain.gain.exponentialRampToValueAtTime(0.001, atTime + 0.05);
+
+	osc.connect(gain);
+	gain.connect(audioContext.destination);
+	osc.start(atTime);
+	osc.stop(atTime + 0.06);
+	osc.onended = () => {
+		osc.disconnect();
+		gain.disconnect();
+	};
+}
+
 // Suspend audio while the page is hidden, resume when it returns
 function handleVisibilityChange(): void {
 	if (!audioContext) return;

--- a/src/lib/stores/metronome.svelte.test.ts
+++ b/src/lib/stores/metronome.svelte.test.ts
@@ -1,0 +1,103 @@
+// Tests for the metronome's lookahead scheduler.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// audioTime is driven by the fake-timer clock so advancing timers advances
+// the "audio context" clock in lockstep
+vi.mock("$stores/audio.svelte", () => ({
+	audioTime: vi.fn(() => Date.now() / 1000),
+	scheduleClick: vi.fn(),
+	unlockAudio: vi.fn(),
+	startChord: vi.fn(),
+	stopChordById: vi.fn(),
+}));
+
+import { scheduleClick, unlockAudio } from "$stores/audio.svelte";
+import {
+	metronome,
+	startMetronome,
+	stopMetronome,
+	toggleMetronome,
+} from "$stores/metronome.svelte";
+import { setBpm } from "$stores/progressionPlayer.svelte";
+
+function clickCalls() {
+	return vi.mocked(scheduleClick).mock.calls;
+}
+
+describe("metronome", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stopMetronome();
+		setBpm(120);
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		stopMetronome();
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+	});
+
+	it("unlocks audio and starts scheduling clicks", () => {
+		startMetronome();
+		expect(unlockAudio).toHaveBeenCalled();
+		expect(metronome.running).toBe(true);
+		// The first scheduler pass books at least the first beat
+		expect(clickCalls().length).toBeGreaterThan(0);
+	});
+
+	it("schedules beats one beat-interval apart at the current tempo", () => {
+		startMetronome();
+		vi.advanceTimersByTime(2000); // 2s at 120 BPM ≈ 4 beats
+
+		const times = clickCalls().map(([time]) => time);
+		expect(times.length).toBeGreaterThanOrEqual(4);
+		for (let i = 1; i < times.length; i++) {
+			expect(times[i] - times[i - 1]).toBeCloseTo(0.5, 3); // 60/120
+		}
+	});
+
+	it("accents the downbeat of every 4/4 bar", () => {
+		startMetronome();
+		vi.advanceTimersByTime(4000); // ≈ 8 beats
+
+		const accents = clickCalls().map(([, accent]) => accent);
+		expect(accents[0]).toBe(true);
+		expect(accents.slice(1, 4)).toEqual([false, false, false]);
+		expect(accents[4]).toBe(true);
+	});
+
+	it("retunes live when the tempo changes", () => {
+		startMetronome();
+		vi.advanceTimersByTime(1000);
+		setBpm(60);
+		const before = clickCalls().length;
+		vi.advanceTimersByTime(2000); // 2s at 60 BPM = 2 more beats
+
+		const times = clickCalls()
+			.slice(before)
+			.map(([time]) => time);
+		for (let i = 1; i < times.length; i++) {
+			expect(times[i] - times[i - 1]).toBeCloseTo(1, 3); // 60/60
+		}
+	});
+
+	it("stops scheduling when stopped", () => {
+		startMetronome();
+		vi.advanceTimersByTime(1000);
+		stopMetronome();
+		expect(metronome.running).toBe(false);
+
+		const calls = clickCalls().length;
+		vi.advanceTimersByTime(2000);
+		expect(clickCalls().length).toBe(calls);
+	});
+
+	it("toggles", () => {
+		toggleMetronome();
+		expect(metronome.running).toBe(true);
+		toggleMetronome();
+		expect(metronome.running).toBe(false);
+	});
+});

--- a/src/lib/stores/metronome.svelte.ts
+++ b/src/lib/stores/metronome.svelte.ts
@@ -1,0 +1,59 @@
+// Metronome / click track. Uses the standard Web Audio lookahead pattern:
+// a coarse setInterval wakes every ~25ms and schedules any clicks that fall
+// inside the next ~100ms window on the AudioContext clock — precise,
+// drift-free timing regardless of main-thread jitter. Tempo comes live from
+// the shared player.bpm, so tap tempo and the bpm input retune the click
+// immediately.
+
+import { audioTime, scheduleClick, unlockAudio } from "$stores/audio.svelte";
+import { player } from "$stores/progressionPlayer.svelte";
+
+const LOOKAHEAD_MS = 25;
+const SCHEDULE_AHEAD_S = 0.1;
+const BEATS_PER_BAR = 4; // 4/4 with an accented downbeat
+
+export const metronome = $state({
+	running: false,
+});
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let nextBeatTime = 0;
+let beatIndex = 0;
+
+function scheduler(): void {
+	const now = audioTime();
+	if (now === null) return;
+	while (nextBeatTime < now + SCHEDULE_AHEAD_S) {
+		scheduleClick(nextBeatTime, beatIndex % BEATS_PER_BAR === 0);
+		beatIndex++;
+		nextBeatTime += 60 / player.bpm;
+	}
+}
+
+export function startMetronome(): void {
+	if (metronome.running) return;
+	// Toggling the click is a user gesture — safe to unlock/resume audio here
+	unlockAudio();
+	const now = audioTime();
+	if (now === null) return;
+
+	beatIndex = 0;
+	nextBeatTime = now + 0.05;
+	metronome.running = true;
+	scheduler();
+	intervalId = setInterval(scheduler, LOOKAHEAD_MS);
+}
+
+export function stopMetronome(): void {
+	if (intervalId) clearInterval(intervalId);
+	intervalId = null;
+	metronome.running = false;
+}
+
+export function toggleMetronome(): void {
+	if (metronome.running) {
+		stopMetronome();
+	} else {
+		startMetronome();
+	}
+}

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -110,6 +110,26 @@ describe("progression player", () => {
 		expect(player.position).toBe(1);
 	});
 
+	it("sets tempo from tap intervals and resets after a long pause", async () => {
+		const { tapTempo } = await import("$stores/progressionPlayer.svelte");
+
+		// Steady taps 500ms apart → 120 BPM
+		tapTempo();
+		for (let i = 0; i < 3; i++) {
+			vi.advanceTimersByTime(500);
+			tapTempo();
+		}
+		expect(player.bpm).toBe(120);
+
+		// A >2s pause starts a fresh sequence: the stale interval is ignored
+		vi.advanceTimersByTime(3000);
+		tapTempo(); // first tap of the new sequence — no bpm change yet
+		expect(player.bpm).toBe(120);
+		vi.advanceTimersByTime(1000);
+		tapTempo();
+		expect(player.bpm).toBe(60); // 1000ms interval
+	});
+
 	it("clamps and persists the tempo", () => {
 		setBpm(999);
 		expect(player.bpm).toBe(240);

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -56,6 +56,29 @@ export function toggleLoop(): void {
 	player.loop = !player.loop;
 }
 
+// Tap tempo: average the intervals of the most recent taps. A pause longer
+// than 2s starts a fresh tap sequence.
+const TAP_RESET_MS = 2000;
+const TAP_WINDOW = 5;
+let tapTimes: number[] = [];
+
+export function tapTempo(): void {
+	const now = Date.now();
+	if (
+		tapTimes.length > 0 &&
+		now - tapTimes[tapTimes.length - 1] > TAP_RESET_MS
+	) {
+		tapTimes = [];
+	}
+	tapTimes.push(now);
+	if (tapTimes.length < 2) return;
+
+	const recent = tapTimes.slice(-TAP_WINDOW);
+	const elapsed = recent[recent.length - 1] - recent[0];
+	const averageInterval = elapsed / (recent.length - 1);
+	setBpm(60_000 / averageInterval);
+}
+
 let stepTimeout: ReturnType<typeof setTimeout> | null = null;
 let releaseTimeout: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@ import Instrument from "$components/Instrument.svelte";
 import ProgressionPad from "$components/ProgressionPad.svelte";
 import SettingsPanel from "$components/SettingsPanel.svelte";
 import SeventhPad from "$components/SeventhPad.svelte";
+import TempoControls from "$components/TempoControls.svelte";
 import VolumeControl from "$components/VolumeControl.svelte";
 
 import { settings } from "$stores/settings.svelte";
@@ -56,11 +57,13 @@ function closeMenuOnOutsidePress(event: PointerEvent) {
 		{/if}
 
 		<!-- toolbar -->
-		<div data-toolbar class="flex items-center gap-6">
+		<div data-toolbar class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
 			<!-- volume control -->
 			<div class="">
 				<VolumeControl />
 			</div>
+			<!-- tempo: bpm / tap / click -->
+			<TempoControls />
 			<!-- seventh modifier (chords mode only) -->
 			{#if settings.mode === "chords"}
 				<SeventhPad />


### PR DESCRIPTION
## Summary

Phase B1 from the roadmap, plus tap tempo:

- **Metronome**: a **click** toggle in the toolbar — 4/4 with accented downbeat, scheduled via the standard Web Audio lookahead pattern (25ms interval booking clicks ~100ms ahead on the AudioContext clock, drift-free). Clicks route straight to the destination, bypassing the reverb send, so the click stays crisp.
- **Tap tempo**: tap in time to set the BPM (averages the last 5 intervals; a 2s pause starts fresh).
- **TempoControls** (bpm / tap / click) in the toolbar. One shared tempo drives the click, pad playback, hold-duration quantization, and MIDI export; changing tempo retunes a running click live. The bpm input moved out of the pad.

## Test plan
- [x] 278 tests passing (+14): scheduler beat spacing/accents/live retune on a fake clock, tap averaging + reset, click blip parameters + dry routing, toolbar controls
- [x] svelte-check, biome, build, fallow audit clean
- [ ] Manual: toggle the click, tap a tempo, hear the click follow; play the pad against the click