### PR TITLE
feat: metronome accent toggle and time signature setting (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-07-12
+
+### Added
+- **Time signature** setting (2/4, 3/4, 4/4, 5/4, 6/8) — decides where bars fall for the metronome's accent pattern (and future bar-based features)
+- **Accent metronome downbeat** setting — when on, the click accents beat 1 of each bar per the time signature
+
+### Changed
+- The metronome click is now unaccented by default (a fixed 4/4 accent fought waltzes and other meters)
+
 ## [0.11.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.11.0
+**Current Version**: 0.12.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -118,6 +118,36 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 		<p class="text-xs opacity-60">Press R to toggle reverb on and off.</p>
 	</div>
 
+	<!-- Time Signature -->
+	<div class="flex flex-col gap-2">
+		<label for="time-signature-select" class="text-sm opacity-80">Time Signature</label>
+		<select
+			id="time-signature-select"
+			bind:value={settings.timeSignature}
+			class="bg-primary/20 border border-neutral-100/20 rounded px-3 py-2 text-sm"
+		>
+			<option value="2/4">2/4</option>
+			<option value="3/4">3/4</option>
+			<option value="4/4">4/4</option>
+			<option value="5/4">5/4</option>
+			<option value="6/8">6/8</option>
+		</select>
+	</div>
+
+	<!-- Metronome Accent -->
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-3">
+			<input
+				id="metronome-accent-toggle"
+				type="checkbox"
+				bind:checked={settings.metronomeAccent}
+				class="w-4 h-4 accent-accent cursor-pointer"
+			/>
+			<label for="metronome-accent-toggle" class="text-sm opacity-80 cursor-pointer">Accent metronome downbeat</label>
+		</div>
+		<p class="text-xs opacity-60">When on, the click accents beat 1 of each bar per the time signature.</p>
+	</div>
+
 	<!-- Progression Pad visibility (only in chords mode) -->
 	{#if settings.mode === "chords"}
 		<div class="flex items-center gap-3">
@@ -168,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.11.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.12.0</div>
 </div>

--- a/src/lib/components/SettingsPanel.svelte.test.ts
+++ b/src/lib/components/SettingsPanel.svelte.test.ts
@@ -145,6 +145,21 @@ describe("SettingsPanel", () => {
 		expect(audioState.reverbMix).toBe(0.6);
 	});
 
+	it("binds the time signature and metronome accent settings", async () => {
+		const user = userEvent.setup();
+		settings.timeSignature = "4/4";
+		settings.metronomeAccent = false;
+		render(SettingsPanel);
+
+		await user.selectOptions(screen.getByLabelText("Time Signature"), "3/4");
+		expect(settings.timeSignature).toBe("3/4");
+
+		const accent = screen.getByLabelText("Accent metronome downbeat");
+		expect(accent).not.toBeChecked();
+		await user.click(accent);
+		expect(settings.metronomeAccent).toBe(true);
+	});
+
 	it("links to the About page", () => {
 		render(SettingsPanel);
 		const about = screen.getByRole("link", { name: "About Fifths →" });

--- a/src/lib/stores/metronome.svelte.test.ts
+++ b/src/lib/stores/metronome.svelte.test.ts
@@ -20,6 +20,7 @@ import {
 	toggleMetronome,
 } from "$stores/metronome.svelte";
 import { setBpm } from "$stores/progressionPlayer.svelte";
+import { settings } from "$stores/settings.svelte";
 
 function clickCalls() {
 	return vi.mocked(scheduleClick).mock.calls;
@@ -30,6 +31,8 @@ describe("metronome", () => {
 		vi.useFakeTimers();
 		stopMetronome();
 		setBpm(120);
+		settings.metronomeAccent = false;
+		settings.timeSignature = "4/4";
 		vi.clearAllMocks();
 	});
 
@@ -58,7 +61,17 @@ describe("metronome", () => {
 		}
 	});
 
-	it("accents the downbeat of every 4/4 bar", () => {
+	it("plays every beat unaccented by default", () => {
+		startMetronome();
+		vi.advanceTimersByTime(4000); // ≈ 8 beats
+
+		const accents = clickCalls().map(([, accent]) => accent);
+		expect(accents.length).toBeGreaterThanOrEqual(8);
+		expect(accents.every((accent) => accent === false)).toBe(true);
+	});
+
+	it("accents the downbeat of every 4/4 bar when the accent setting is on", () => {
+		settings.metronomeAccent = true;
 		startMetronome();
 		vi.advanceTimersByTime(4000); // ≈ 8 beats
 
@@ -66,6 +79,18 @@ describe("metronome", () => {
 		expect(accents[0]).toBe(true);
 		expect(accents.slice(1, 4)).toEqual([false, false, false]);
 		expect(accents[4]).toBe(true);
+	});
+
+	it("follows the time signature for the accent pattern (3/4 waltz)", () => {
+		settings.metronomeAccent = true;
+		settings.timeSignature = "3/4";
+		startMetronome();
+		vi.advanceTimersByTime(3500); // ≈ 7 beats
+
+		const accents = clickCalls()
+			.slice(0, 7)
+			.map(([, accent]) => accent);
+		expect(accents).toEqual([true, false, false, true, false, false, true]);
 	});
 
 	it("retunes live when the tempo changes", () => {

--- a/src/lib/stores/metronome.svelte.ts
+++ b/src/lib/stores/metronome.svelte.ts
@@ -7,10 +7,10 @@
 
 import { audioTime, scheduleClick, unlockAudio } from "$stores/audio.svelte";
 import { player } from "$stores/progressionPlayer.svelte";
+import { beatsPerBar, settings } from "$stores/settings.svelte";
 
 const LOOKAHEAD_MS = 25;
 const SCHEDULE_AHEAD_S = 0.1;
-const BEATS_PER_BAR = 4; // 4/4 with an accented downbeat
 
 export const metronome = $state({
 	running: false,
@@ -24,7 +24,10 @@ function scheduler(): void {
 	const now = audioTime();
 	if (now === null) return;
 	while (nextBeatTime < now + SCHEDULE_AHEAD_S) {
-		scheduleClick(nextBeatTime, beatIndex % BEATS_PER_BAR === 0);
+		// Accent the bar's downbeat only when the setting is on; the time
+		// signature decides where bars fall
+		const accent = settings.metronomeAccent && beatIndex % beatsPerBar() === 0;
+		scheduleClick(nextBeatTime, accent);
 		beatIndex++;
 		nextBeatTime += 60 / player.bpm;
 	}

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -26,4 +26,14 @@ export const settings = $state({
 		| "B",
 	keyCenterPosition: "bottom" as "top" | "bottom",
 	showProgressionPad: true,
+	// Metronome: accent the downbeat of each bar (off by default — a fixed
+	// accent fights odd meters unless the time signature matches)
+	metronomeAccent: false,
+	timeSignature: "4/4" as "2/4" | "3/4" | "4/4" | "5/4" | "6/8",
 });
+
+// Beats per bar from the time signature's numerator (drives the accent
+// pattern and, later, bar-based features like the drum machine)
+export function beatsPerBar(): number {
+	return Number(settings.timeSignature.split("/")[0]);
+}


### PR DESCRIPTION
## Summary

A fixed 4/4 accent fought waltzes and other meters:

- The click is now **unaccented by default**
- New **"Accent metronome downbeat"** setting (off by default) turns the accent on
- New **time signature** setting (2/4, 3/4, 4/4, 5/4, 6/8) decides where bars fall for the accent pattern — and `beatsPerBar()` is exported for future bar-based features (drum machine, song engine)

## Test plan
- [x] 281 tests passing (+3): unaccented default, 4/4 accent when enabled, 3/4 waltz pattern, settings bindings
- [x] svelte-check, biome, build clean
- [ ] Manual: click in 3/4 with accent on → ONE-two-three; accent off → even clicks