### PR TITLE
feat: playback click and measure separators (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-12
+
+### Added
+- Playback click: a **click** checkbox in the progression pad plays a click during playback, beat-aligned with the chords (honors the accent and time-signature settings)
+- Measure separators: the pad now draws vertical pipes between measures, derived from each chord's beats and the time signature; the bar count restarts on each line, like a lead sheet
+
+### Changed
+- The live metronome yields when playback starts (two clocks would fight) and is restored when the transport disengages — so punching in after playback keeps the click going
+
 ## [0.12.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.12.0
+**Current Version**: 0.13.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -27,18 +27,33 @@ import {
 	stopPlayback,
 	toggleLoop,
 } from "$stores/progressionPlayer.svelte";
-import { settings } from "$stores/settings.svelte";
+import { beatsPerBar, settings } from "$stores/settings.svelte";
+
+type Chip = { kind: "chord"; label: string; index: number } | { kind: "bar" };
 
 // Group flat entries into visual lines at each break, keeping each chord's
-// index into progression.entries so the sounding chord can be highlighted
+// index into progression.entries so the sounding chord can be highlighted.
+// Measures are separated with a pipe when accumulated beats cross a bar
+// boundary (per the time signature); the bar count restarts on each line,
+// like a lead sheet.
 const lines = $derived.by(() => {
-	const grouped: { label: string; index: number }[][] = [[]];
+	const barBeats = beatsPerBar();
+	const grouped: Chip[][] = [[]];
+	let beatsInBar = 0;
+
 	progression.entries.forEach((entry, index) => {
 		if (entry.kind === "break") {
 			grouped.push([]);
-		} else {
-			grouped[grouped.length - 1].push({ label: entry.label, index });
+			beatsInBar = 0;
+			return;
 		}
+		const line = grouped[grouped.length - 1];
+		if (beatsInBar >= barBeats) {
+			line.push({ kind: "bar" });
+			beatsInBar = beatsInBar % barBeats;
+		}
+		line.push({ kind: "chord", label: entry.label, index });
+		beatsInBar += entry.beats;
 	});
 	return grouped;
 });
@@ -87,11 +102,15 @@ const activeClasses = "text-accent border-accent/60";
 			{#each lines as line}
 				<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
 					{#each line as chip}
-						<span
-							class={player.position === chip.index
-								? "text-accent"
-								: "opacity-90"}
-						>{chip.label}</span>
+						{#if chip.kind === "bar"}
+							<span class="opacity-40 select-none" aria-hidden="true">|</span>
+						{:else}
+							<span
+								class={player.position === chip.index
+									? "text-accent"
+									: "opacity-90"}
+							>{chip.label}</span>
+						{/if}
 					{/each}
 				</div>
 			{/each}
@@ -128,6 +147,20 @@ const activeClasses = "text-accent border-accent/60";
 			>
 				loop
 			</button>
+
+			<!-- playback click (the live metronome yields during playback) -->
+			<label
+				class="flex items-center gap-1.5 text-xs opacity-80 cursor-pointer"
+				title="Play a click during playback"
+			>
+				<input
+					type="checkbox"
+					bind:checked={player.clickAlong}
+					class="w-3.5 h-3.5 accent-accent cursor-pointer"
+					aria-label="Click during playback"
+				/>
+				click
+			</label>
 
 			<!-- recorder -->
 			<button

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -7,6 +7,7 @@ import {
 	clearProgression,
 	progression,
 	recordChord,
+	setEntryBeats,
 } from "$stores/progression.svelte";
 import { player, setBpm, stopPlayback } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
@@ -22,8 +23,10 @@ describe("ProgressionPad", () => {
 		progression.recording = true;
 		progression.suspended = false;
 		player.loop = false;
+		player.clickAlong = false;
 		setBpm(120);
 		settings.showProgressionPad = true;
+		settings.timeSignature = "4/4";
 	});
 
 	it("renders nothing while the pad is empty", () => {
@@ -103,6 +106,53 @@ describe("ProgressionPad", () => {
 		expect(loop).toHaveAttribute("aria-pressed", "false");
 		await user.click(loop);
 		expect(player.loop).toBe(true);
+	});
+
+	it("separates measures with pipes per the time signature", () => {
+		settings.timeSignature = "4/4";
+		// Four 1-beat chords fill a bar; the fifth starts a new one
+		for (const label of ["C", "F", "G", "Am", "C"]) {
+			recordChord(label, [60]);
+		}
+		render(ProgressionPad);
+		const row = screen
+			.getByLabelText("Jotted progression")
+			.querySelector(":scope > div");
+		const chips = Array.from(row?.querySelectorAll("span") ?? []).map(
+			(span) => span.textContent,
+		);
+		expect(chips).toEqual(["C", "F", "G", "Am", "|", "C"]);
+	});
+
+	it("counts multi-beat chords toward the bar and resets bars per line", async () => {
+		settings.timeSignature = "4/4";
+		recordChord("C", [60]);
+		setEntryBeats(0, 2);
+		recordChord("G", [55]);
+		setEntryBeats(1, 2);
+		recordChord("Am", [57]); // bar boundary before this chord
+		addLineBreak();
+		recordChord("F", [53]); // new line: bar count restarts, no pipe
+		render(ProgressionPad);
+
+		const rows = screen
+			.getByLabelText("Jotted progression")
+			.querySelectorAll(":scope > div");
+		const rowChips = (row: Element) =>
+			Array.from(row.querySelectorAll("span")).map((span) => span.textContent);
+		expect(rowChips(rows[0])).toEqual(["C", "G", "|", "Am"]);
+		expect(rowChips(rows[1])).toEqual(["F"]);
+	});
+
+	it("binds the playback click checkbox", async () => {
+		const user = userEvent.setup();
+		recordChord("C", [60, 64, 67]);
+		render(ProgressionPad);
+
+		const clickAlong = screen.getByLabelText("Click during playback");
+		expect(clickAlong).not.toBeChecked();
+		await user.click(clickAlong);
+		expect(player.clickAlong).toBe(true);
 	});
 
 	it("no longer hosts the tempo input (moved to the toolbar)", () => {

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -198,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.12.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.13.0</div>
 </div>

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -3,11 +3,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("$stores/audio.svelte", () => ({
+	audioTime: vi.fn(() => Date.now() / 1000),
+	scheduleClick: vi.fn(),
 	startChord: vi.fn(),
 	stopChordById: vi.fn(),
+	unlockAudio: vi.fn(),
 }));
 
-import { startChord, stopChordById } from "$stores/audio.svelte";
+import { scheduleClick, startChord, stopChordById } from "$stores/audio.svelte";
+import {
+	metronome,
+	startMetronome,
+	stopMetronome,
+} from "$stores/metronome.svelte";
 import {
 	addLineBreak,
 	clearProgression,
@@ -36,13 +44,17 @@ describe("progression player", () => {
 		// Reset player state BEFORE clearing mocks — stopPlayback itself
 		// calls the mocked stopChordById
 		stopPlayback();
+		stopMetronome();
 		player.loop = false;
+		player.clickAlong = false;
 		setBpm(120);
 		vi.clearAllMocks();
 		clearProgression();
 		progression.recording = true;
 		progression.suspended = false;
 		settings.activeVoice = "sine";
+		settings.metronomeAccent = false;
+		settings.timeSignature = "4/4";
 	});
 
 	afterEach(() => {
@@ -176,6 +188,63 @@ describe("progression player", () => {
 
 		stopPlayback();
 		expect(progression.suspended).toBe(false);
+	});
+
+	it("plays no click during playback by default", () => {
+		recordChord("C", C_NOTES);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS);
+		expect(scheduleClick).not.toHaveBeenCalled();
+	});
+
+	it("schedules beat-aligned clicks during playback when clickAlong is on", () => {
+		player.clickAlong = true;
+		recordChord("C", C_NOTES);
+		setEntryBeats(0, 2);
+		recordChord("G", G_NOTES);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS * 3);
+
+		// 2 beats for C + 1 for G
+		const times = vi.mocked(scheduleClick).mock.calls.map(([time]) => time);
+		expect(times).toHaveLength(3);
+		// C's two beats are half a second apart on the audio clock
+		expect(times[1] - times[0]).toBeCloseTo(0.5, 3);
+	});
+
+	it("accents playback clicks per the time signature when enabled", () => {
+		player.clickAlong = true;
+		settings.metronomeAccent = true;
+		settings.timeSignature = "2/4";
+		for (let i = 0; i < 4; i++) recordChord("C", C_NOTES);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS * 4);
+
+		const accents = vi
+			.mocked(scheduleClick)
+			.mock.calls.map(([, accent]) => accent);
+		expect(accents).toEqual([true, false, true, false]);
+	});
+
+	it("stops the live click for playback and restores it after", () => {
+		recordChord("C", C_NOTES);
+		startMetronome();
+		expect(metronome.running).toBe(true);
+
+		playProgression();
+		expect(metronome.running).toBe(false); // live click yields
+
+		vi.advanceTimersByTime(STEP_MS); // natural end
+		expect(player.playing).toBe(false);
+		expect(metronome.running).toBe(true); // restored for punch-in
+		stopMetronome();
+	});
+
+	it("does not restore the live click if it was not running before", () => {
+		recordChord("C", C_NOTES);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS);
+		expect(metronome.running).toBe(false);
 	});
 
 	it("rests on line breaks", () => {

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -6,9 +6,20 @@
 // the suspension lifts and — with ● rec on — the next chord played appends:
 // a DAW-style punch-in.
 
-import { startChord, stopChordById } from "$stores/audio.svelte";
+import {
+	audioTime,
+	scheduleClick,
+	startChord,
+	stopChordById,
+	unlockAudio,
+} from "$stores/audio.svelte";
+import {
+	metronome,
+	startMetronome,
+	stopMetronome,
+} from "$stores/metronome.svelte";
 import { progression } from "$stores/progression.svelte";
-import { settings } from "$stores/settings.svelte";
+import { beatsPerBar, settings } from "$stores/settings.svelte";
 
 import { midiToFrequency } from "$utils/midi";
 import { beatMs } from "$utils/rhythm";
@@ -36,6 +47,8 @@ export const player = $state({
 	playing: false,
 	paused: false,
 	loop: false,
+	// Play a click during playback (the pad's checkbox)
+	clickAlong: false,
 	bpm: loadBpm(),
 	// Index into progression.entries of the sounding chord, -1 when idle
 	position: -1,
@@ -93,6 +106,36 @@ function entryBeats(entry: (typeof progression.entries)[number]): number {
 	return entry.kind === "chord" ? entry.beats : 1; // breaks rest one beat
 }
 
+// --- playback click ---------------------------------------------------------
+// The live metronome yields to playback (two clocks would fight); when
+// clickAlong is on, the player schedules its own clicks per step so they stay
+// beat-aligned with the chords. Accent/time-signature settings apply.
+
+// Absolute beat number within this playback run, for accent placement
+let playbackBeatCount = 0;
+// Whether the live click was running when playback started (restored on stop)
+let liveClickWasRunning = false;
+
+function scheduleStepClicks(beats: number): void {
+	const now = audioTime();
+	if (now === null) return;
+	const interval = 60 / player.bpm;
+	for (let beat = 0; beat < beats; beat++) {
+		const accent =
+			settings.metronomeAccent && playbackBeatCount % beatsPerBar() === 0;
+		scheduleClick(now + beat * interval, accent);
+		playbackBeatCount++;
+	}
+}
+
+// Beats that precede a given entry index (aligns the accent counter when
+// resuming from a pause)
+function beatsBefore(index: number): number {
+	return progression.entries
+		.slice(0, index)
+		.reduce((sum, entry) => sum + entryBeats(entry), 0);
+}
+
 function step(index: number): void {
 	// Entries can shrink mid-playback (undo/clear) — re-check every step
 	if (!player.playing) return;
@@ -108,6 +151,10 @@ function step(index: number): void {
 	const entry = progression.entries[index];
 	player.position = index;
 	const durationMs = entryBeats(entry) * beatMs(player.bpm);
+
+	if (player.clickAlong) {
+		scheduleStepClicks(entryBeats(entry));
+	}
 
 	if (entry.kind === "chord" && entry.notes.length > 0) {
 		startChord(
@@ -128,9 +175,21 @@ export function playProgression(): void {
 	if (player.playing && !player.paused) return;
 	if (progression.entries.length === 0) return;
 
+	// The live click yields to playback; remember it so stopping restores it
+	if (metronome.running) {
+		liveClickWasRunning = true;
+		stopMetronome();
+	}
+	// Pressing play is a user gesture — make sure the context is up so the
+	// playback click can schedule even if the first entry is a rest
+	if (player.clickAlong) {
+		unlockAudio();
+	}
+
 	// Resume from a pause, or start from the top
 	const startIndex =
 		player.paused && player.position >= 0 ? player.position : 0;
+	playbackBeatCount = beatsBefore(startIndex);
 	player.playing = true;
 	player.paused = false;
 	progression.suspended = true;
@@ -154,4 +213,10 @@ export function stopPlayback(): void {
 	player.position = -1;
 	// Transport disengaged: live jotting may resume (punch-in moment)
 	progression.suspended = false;
+	// Bring the live click back if playback displaced it — so punching in
+	// after playback keeps the click going
+	if (liveClickWasRunning) {
+		liveClickWasRunning = false;
+		startMetronome();
+	}
 }


### PR DESCRIPTION
## Summary

**Playback click**
- New **click** checkbox in the pad transport row: during playback the player schedules its own clicks, beat-aligned with the chords on the audio clock, honoring the accent/time-signature settings
- The **live metronome yields** when playback starts (two clocks would drift against each other) and is **restored** when the transport disengages — so punching in after playback keeps the click going

**Measure separators**
- The pad draws vertical pipes between measures, derived from each chord's beats and the time signature
- The bar count restarts on each line break, lead-sheet style

## Test plan
- [x] 289 tests passing (+8): click scheduling/spacing/accents during playback, live-click yield + restore, checkbox binding, pipe placement (1-beat and multi-beat chords, per-line reset)
- [x] svelte-check, biome, build clean
- [ ] Manual: live click on → play → click follows the recording → end → live click returns; pipes match the time signature