### PR TITLE
feat: drier click voice (v0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-07-12
+
+### Changed
+- Drier click voice: the metronome is now a ~15ms band-passed white-noise burst instead of a 50ms square-wave beep — no pitch content, reads as a tick rather than a tone. The accent is brighter and louder (higher filter center) instead of higher-pitched.
+
 ## [0.13.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.13.0
+**Current Version**: 0.13.1
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -198,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.13.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.13.1</div>
 </div>

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -46,6 +46,23 @@ class FakeConvolverNode {
 	disconnect = vi.fn();
 }
 
+class FakeBufferSourceNode {
+	buffer: unknown = null;
+	connect = vi.fn();
+	disconnect = vi.fn();
+	start = vi.fn();
+	stop = vi.fn();
+	onended: (() => void) | null = null;
+}
+
+class FakeBiquadFilterNode {
+	type = "lowpass";
+	frequency = new FakeAudioParam();
+	Q = new FakeAudioParam();
+	connect = vi.fn();
+	disconnect = vi.fn();
+}
+
 class FakeAudioBuffer {
 	numberOfChannels = 2;
 	channels: Float32Array[];
@@ -75,6 +92,8 @@ class FakeAudioContext {
 	createdGains: FakeGainNode[] = [];
 	createdOscillators: FakeOscillatorNode[] = [];
 	createdConvolvers: FakeConvolverNode[] = [];
+	createdBufferSources: FakeBufferSourceNode[] = [];
+	createdFilters: FakeBiquadFilterNode[] = [];
 
 	constructor() {
 		FakeAudioContext.instances.push(this);
@@ -96,6 +115,18 @@ class FakeAudioContext {
 		const convolver = new FakeConvolverNode();
 		this.createdConvolvers.push(convolver);
 		return convolver;
+	}
+
+	createBufferSource() {
+		const source = new FakeBufferSourceNode();
+		this.createdBufferSources.push(source);
+		return source;
+	}
+
+	createBiquadFilter() {
+		const filter = new FakeBiquadFilterNode();
+		this.createdFilters.push(filter);
+		return filter;
 	}
 
 	createBuffer(channels: number, length: number, _sampleRate: number) {
@@ -512,32 +543,48 @@ describe("audio store", () => {
 			expect(audio.audioTime()).toBe(0);
 		});
 
-		it("scheduleClick books a short dry blip at the exact time", async () => {
+		it("scheduleClick books a short filtered noise burst at the exact time", async () => {
 			const audio = await freshStore();
 			await audio.startChord(C_MAJOR, "sine", 1);
 			const ctx = FakeAudioContext.instances[0];
-			const oscillatorsBefore = ctx.createdOscillators.length;
 
 			audio.scheduleClick(1.5, true);
 
-			const osc = ctx.createdOscillators[oscillatorsBefore];
-			expect(osc.type).toBe("square");
-			expect(osc.frequency.setValueAtTime).toHaveBeenCalledWith(1600, 1.5);
-			expect(osc.start).toHaveBeenCalledWith(1.5);
-			expect(osc.stop).toHaveBeenCalledWith(1.56);
+			// Noise voice, not an oscillator: no pitch content
+			const source = ctx.createdBufferSources.at(-1);
+			expect(source?.buffer).not.toBeNull();
+			expect(source?.start).toHaveBeenCalledWith(1.5);
+			expect(source?.stop).toHaveBeenCalledWith(1.52); // ~20ms tick
+
+			// Band-passed; the accent is brighter, not higher-pitched
+			const filter = ctx.createdFilters.at(-1);
+			expect(filter?.type).toBe("bandpass");
+			expect(filter?.frequency.setValueAtTime).toHaveBeenCalledWith(6000, 1.5);
+
 			// Dry path: the click gain connects straight to the destination
 			const clickGain = ctx.createdGains.at(-1);
 			expect(clickGain?.connect).toHaveBeenCalledWith(ctx.destination);
 		});
 
-		it("unaccented clicks use the lower pitch", async () => {
+		it("unaccented clicks use the darker filter center", async () => {
 			const audio = await freshStore();
 			await audio.startChord(C_MAJOR, "sine", 1);
 			const ctx = FakeAudioContext.instances[0];
 
 			audio.scheduleClick(2, false);
-			const osc = ctx.createdOscillators.at(-1);
-			expect(osc?.frequency.setValueAtTime).toHaveBeenCalledWith(1100, 2);
+			const filter = ctx.createdFilters.at(-1);
+			expect(filter?.frequency.setValueAtTime).toHaveBeenCalledWith(3500, 2);
+		});
+
+		it("reuses one shared noise buffer across clicks", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			const ctx = FakeAudioContext.instances[0];
+
+			audio.scheduleClick(1);
+			audio.scheduleClick(2);
+			const [first, second] = ctx.createdBufferSources.slice(-2);
+			expect(first.buffer).toBe(second.buffer);
 		});
 
 		it("is a no-op before the context exists", async () => {

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -149,28 +149,51 @@ export function audioTime(): number | null {
 	return audioContext ? audioContext.currentTime : null;
 }
 
-// Schedule a short metronome click at an exact context time. Clicks connect
-// straight to the destination (not through the master chain) so they stay
-// dry — a reverberant click defeats the purpose — scaled by master volume.
+// Shared white-noise buffer for the click voice, built once per context
+let clickNoiseBuffer: AudioBuffer | null = null;
+function getClickNoiseBuffer(ctx: AudioContext): AudioBuffer {
+	if (!clickNoiseBuffer) {
+		const length = Math.max(1, Math.floor(ctx.sampleRate * 0.05));
+		clickNoiseBuffer = ctx.createBuffer(1, length, ctx.sampleRate);
+		const data = clickNoiseBuffer.getChannelData(0);
+		for (let i = 0; i < length; i++) {
+			data[i] = Math.random() * 2 - 1;
+		}
+	}
+	return clickNoiseBuffer;
+}
+
+// Schedule a short metronome click at an exact context time. The voice is a
+// ~15ms band-passed noise burst: noise has no pitch and the burst is too
+// short for pitch perception to engage, so the click reads as a dry tick
+// rather than a tone. The accent is brighter and louder, not higher-pitched.
+// Clicks connect straight to the destination (not through the master chain)
+// so they stay out of the reverb, scaled by master volume.
 export function scheduleClick(atTime: number, accent = false): void {
 	if (!audioContext) return;
 
-	const osc = audioContext.createOscillator();
+	const source = audioContext.createBufferSource();
+	source.buffer = getClickNoiseBuffer(audioContext);
+
+	// Low Q = broad band = dry; higher center frequency = brighter accent
+	const filter = audioContext.createBiquadFilter();
+	filter.type = "bandpass";
+	filter.frequency.setValueAtTime(accent ? 6000 : 3500, atTime);
+	filter.Q.value = 1.2;
+
 	const gain = audioContext.createGain();
-	osc.type = "square";
-	osc.frequency.setValueAtTime(accent ? 1600 : 1100, atTime);
+	const peak = 0.5 * audioState.masterVolume * (accent ? 1.5 : 1);
+	gain.gain.setValueAtTime(peak, atTime);
+	gain.gain.exponentialRampToValueAtTime(0.001, atTime + 0.015);
 
-	const peak = 0.25 * audioState.masterVolume * (accent ? 1.4 : 1);
-	gain.gain.setValueAtTime(0, atTime);
-	gain.gain.linearRampToValueAtTime(peak, atTime + 0.002);
-	gain.gain.exponentialRampToValueAtTime(0.001, atTime + 0.05);
-
-	osc.connect(gain);
+	source.connect(filter);
+	filter.connect(gain);
 	gain.connect(audioContext.destination);
-	osc.start(atTime);
-	osc.stop(atTime + 0.06);
-	osc.onended = () => {
-		osc.disconnect();
+	source.start(atTime);
+	source.stop(atTime + 0.02);
+	source.onended = () => {
+		source.disconnect();
+		filter.disconnect();
 		gain.disconnect();
 	};
 }


### PR DESCRIPTION
## Summary

The metronome click is now a **~15ms band-passed white-noise burst** instead of a 50ms square-wave beep:

- Noise has no pitch, and under ~15ms pitch perception barely engages — the click reads as a dry tick, not a tone
- The accent is **brighter and louder** (6kHz vs 3.5kHz bandpass center, +50% level) rather than higher-pitched
- One shared noise buffer per context; still routed dry, outside the reverb send

## Test plan
- [x] 290 tests passing — click assertions updated (burst timing, filter centers, shared buffer, dry routing)
- [x] svelte-check, biome, build clean
- [ ] Manual: click sounds like a tick, accent reads as brightness not pitch