### PR TITLE
fix: measures no longer drift between display and playback (v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-07-12
+
+### Fixed
+- Playback measures no longer drift from the displayed measures: line breaks silently played as one-beat rests and shifted every following bar off the grid, so a pad showing four chords per measure could play back misaligned
+
+### Removed
+- The "new line" control and break entries — breaks were visual organization but had musical side effects; legacy break entries are dropped on load
+
+### Changed
+- The pad now wraps by whole measures: chords group into measures per the time signature, each measure is an unbreakable unit with its pipe, and lines wrap naturally between measures
+
 ## [0.13.1] - 2026-07-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.13.1
+**Current Version**: 0.14.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.13.1",
+	"version": "0.14.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -7,14 +7,15 @@ Progression pad
   transport is engaged, live jotting is suspended — when playback ends
   naturally with rec on, the next chord played appends (punch-in)
 - ● rec toggles jotting
-- Line break / undo / clear; the X hides the pad (re-enable from settings);
-  content persists in localStorage; hidden until the first chord is played
+- Chords group into measures (per the time signature) separated by pipes;
+  measures wrap as whole units and are never split across lines
+- undo / clear; the X hides the pad (re-enable from settings); content
+  persists in localStorage; hidden until the first chord is played
 - (.mid export exists in $utils/midi but is not surfaced in the UI for now)
 -->
 
 <script lang="ts">
 import {
-	addLineBreak,
 	clearProgression,
 	deleteLast,
 	progression,
@@ -29,30 +30,20 @@ import {
 } from "$stores/progressionPlayer.svelte";
 import { beatsPerBar, settings } from "$stores/settings.svelte";
 
-type Chip = { kind: "chord"; label: string; index: number } | { kind: "bar" };
-
-// Group flat entries into visual lines at each break, keeping each chord's
+// Group chords into measures (per the time signature), keeping each chord's
 // index into progression.entries so the sounding chord can be highlighted.
-// Measures are separated with a pipe when accumulated beats cross a bar
-// boundary (per the time signature); the bar count restarts on each line,
-// like a lead sheet.
-const lines = $derived.by(() => {
+// Each measure renders as an unbreakable unit, so wrapping never splits one.
+const measures = $derived.by(() => {
 	const barBeats = beatsPerBar();
-	const grouped: Chip[][] = [[]];
+	const grouped: { label: string; index: number }[][] = [[]];
 	let beatsInBar = 0;
 
 	progression.entries.forEach((entry, index) => {
-		if (entry.kind === "break") {
-			grouped.push([]);
-			beatsInBar = 0;
-			return;
-		}
-		const line = grouped[grouped.length - 1];
 		if (beatsInBar >= barBeats) {
-			line.push({ kind: "bar" });
+			grouped.push([]);
 			beatsInBar = beatsInBar % barBeats;
 		}
-		line.push({ kind: "chord", label: entry.label, index });
+		grouped[grouped.length - 1].push({ label: entry.label, index });
 		beatsInBar += entry.beats;
 	});
 	return grouped;
@@ -96,22 +87,21 @@ const activeClasses = "text-accent border-accent/60";
 		>&times;</button>
 
 		<div
-			class="grid gap-1 max-h-28 overflow-y-auto font-mono text-sm"
+			class="flex flex-wrap gap-x-2 gap-y-1 max-h-28 overflow-y-auto font-mono text-sm"
 			aria-label="Jotted progression"
 		>
-			{#each lines as line}
-				<div class="flex flex-wrap gap-x-3 gap-y-1 min-h-5">
-					{#each line as chip}
-						{#if chip.kind === "bar"}
-							<span class="opacity-40 select-none" aria-hidden="true">|</span>
-						{:else}
-							<span
-								class={player.position === chip.index
-									? "text-accent"
-									: "opacity-90"}
-							>{chip.label}</span>
-						{/if}
+			{#each measures as measure, m}
+				<div data-measure class="flex gap-x-3 whitespace-nowrap">
+					{#each measure as chip}
+						<span
+							class={player.position === chip.index
+								? "text-accent"
+								: "opacity-90"}
+						>{chip.label}</span>
 					{/each}
+					{#if m < measures.length - 1}
+						<span class="opacity-40 select-none" aria-hidden="true">|</span>
+					{/if}
 				</div>
 			{/each}
 		</div>
@@ -177,9 +167,6 @@ const activeClasses = "text-accent border-accent/60";
 		</div>
 
 		<div class="flex flex-wrap gap-2">
-			<button type="button" class={buttonClasses} onclick={addLineBreak}>
-				new line
-			</button>
 			<button type="button" class={buttonClasses} onclick={deleteLast}>
 				undo
 			</button>

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -3,7 +3,6 @@
 import ProgressionPad from "$components/ProgressionPad.svelte";
 
 import {
-	addLineBreak,
 	clearProgression,
 	progression,
 	recordChord,
@@ -43,17 +42,20 @@ describe("ProgressionPad", () => {
 		expect(pad).toHaveTextContent("Am");
 	});
 
-	it("renders line breaks as separate rows", () => {
-		recordChord("C");
-		addLineBreak();
-		recordChord("G");
+	it("renders each measure as an unbreakable unit", () => {
+		settings.timeSignature = "4/4";
+		for (const label of ["C", "F", "G", "Am", "C", "F"]) {
+			recordChord(label, [60]);
+		}
 		render(ProgressionPad);
-		const rows = screen
+		const groups = screen
 			.getByLabelText("Jotted progression")
-			.querySelectorAll(":scope > div");
-		expect(rows).toHaveLength(2);
-		expect(rows[0]).toHaveTextContent("C");
-		expect(rows[1]).toHaveTextContent("G");
+			.querySelectorAll("[data-measure]");
+		expect(groups).toHaveLength(2);
+		// Measures keep their chords together so wrapping cannot split them
+		expect(groups[0]).toHaveClass("whitespace-nowrap");
+		expect(groups[0].textContent).toContain("Am");
+		expect(groups[1].textContent).toContain("F");
 	});
 
 	it("toggles jotting with the rec button", async () => {
@@ -115,33 +117,25 @@ describe("ProgressionPad", () => {
 			recordChord(label, [60]);
 		}
 		render(ProgressionPad);
-		const row = screen
-			.getByLabelText("Jotted progression")
-			.querySelector(":scope > div");
-		const chips = Array.from(row?.querySelectorAll("span") ?? []).map(
-			(span) => span.textContent,
-		);
+		const chips = Array.from(
+			screen.getByLabelText("Jotted progression").querySelectorAll("span"),
+		).map((span) => span.textContent);
 		expect(chips).toEqual(["C", "F", "G", "Am", "|", "C"]);
 	});
 
-	it("counts multi-beat chords toward the bar and resets bars per line", async () => {
+	it("counts multi-beat chords toward the bar", async () => {
 		settings.timeSignature = "4/4";
 		recordChord("C", [60]);
 		setEntryBeats(0, 2);
 		recordChord("G", [55]);
 		setEntryBeats(1, 2);
 		recordChord("Am", [57]); // bar boundary before this chord
-		addLineBreak();
-		recordChord("F", [53]); // new line: bar count restarts, no pipe
 		render(ProgressionPad);
 
-		const rows = screen
-			.getByLabelText("Jotted progression")
-			.querySelectorAll(":scope > div");
-		const rowChips = (row: Element) =>
-			Array.from(row.querySelectorAll("span")).map((span) => span.textContent);
-		expect(rowChips(rows[0])).toEqual(["C", "G", "|", "Am"]);
-		expect(rowChips(rows[1])).toEqual(["F"]);
+		const chips = Array.from(
+			screen.getByLabelText("Jotted progression").querySelectorAll("span"),
+		).map((span) => span.textContent);
+		expect(chips).toEqual(["C", "G", "|", "Am"]);
 	});
 
 	it("binds the playback click checkbox", async () => {
@@ -190,19 +184,20 @@ describe("ProgressionPad", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("wires the new line, undo, and clear controls", async () => {
+	it("wires the undo and clear controls (new line is gone)", async () => {
 		const user = userEvent.setup();
 		recordChord("C");
 		recordChord("G");
 		render(ProgressionPad);
 
-		await user.click(screen.getByRole("button", { name: "new line" }));
-		expect(progression.entries.at(-1)).toEqual({ kind: "break" });
+		expect(
+			screen.queryByRole("button", { name: "new line" }),
+		).not.toBeInTheDocument();
 
 		await user.click(screen.getByRole("button", { name: "undo" }));
 		expect(progression.entries.at(-1)).toEqual({
 			kind: "chord",
-			label: "G",
+			label: "C",
 			notes: [],
 			beats: 1,
 		});

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -198,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.13.1</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.14.0</div>
 </div>

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -1,7 +1,6 @@
 // Tests for the progression pad store (jotting + localStorage persistence).
 
 import {
-	addLineBreak,
 	clearProgression,
 	deleteLast,
 	progression,
@@ -65,12 +64,10 @@ describe("progression store", () => {
 		expect(stored()[0].beats).toBe(4);
 	});
 
-	it("ignores setEntryBeats for missing or break entries", () => {
+	it("ignores setEntryBeats for missing entries", () => {
 		recordChord("C");
-		addLineBreak();
-		expect(() => setEntryBeats(1, 2)).not.toThrow(); // break
 		expect(() => setEntryBeats(99, 2)).not.toThrow(); // missing
-		expect(progression.entries[1]).toEqual({ kind: "break" });
+		expect(progression.entries).toHaveLength(1);
 	});
 
 	it("records chords in order", () => {
@@ -81,21 +78,6 @@ describe("progression store", () => {
 			{ kind: "chord", label: "C", notes: [], beats: 1 },
 			{ kind: "chord", label: "Am", notes: [], beats: 1 },
 			{ kind: "chord", label: "F7", notes: [], beats: 1 },
-		]);
-	});
-
-	it("adds line breaks between chords but never leading or doubled", () => {
-		addLineBreak(); // leading — ignored
-		expect(progression.entries).toEqual([]);
-
-		recordChord("C");
-		addLineBreak();
-		addLineBreak(); // doubled — ignored
-		recordChord("G");
-		expect(progression.entries).toEqual([
-			{ kind: "chord", label: "C", notes: [], beats: 1 },
-			{ kind: "break" },
-			{ kind: "chord", label: "G", notes: [], beats: 1 },
 		]);
 	});
 
@@ -113,7 +95,6 @@ describe("progression store", () => {
 
 	it("clears the pad", () => {
 		recordChord("C");
-		addLineBreak();
 		recordChord("G");
 		clearProgression();
 		expect(progression.entries).toEqual([]);
@@ -125,12 +106,10 @@ describe("progression store", () => {
 		expect(stored()).toEqual([
 			{ kind: "chord", label: "C", notes: [], beats: 1 },
 		]);
-		addLineBreak();
 		recordChord("G");
 		deleteLast();
 		expect(stored()).toEqual([
 			{ kind: "chord", label: "C", notes: [], beats: 1 },
-			{ kind: "break" },
 		]);
 	});
 });

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -3,20 +3,24 @@
 
 import type { ChordBeats } from "$utils/rhythm";
 
-export type ProgressionEntry =
-	| { kind: "chord"; label: string; notes: number[]; beats: ChordBeats }
-	| { kind: "break" };
+export type ProgressionEntry = {
+	kind: "chord";
+	label: string;
+	notes: number[];
+	beats: ChordBeats;
+};
 
 // v2: chord entries carry MIDI note numbers (for playback and .mid export).
 // The key was bumped from "fifths-progression", intentionally abandoning
 // note-less v1 jottings. `beats` was added later and defaults to 1 when
-// missing, so v2 data upgrades in place.
+// missing, so v2 data upgrades in place. Legacy "break" entries (the removed
+// new-line feature — they silently played as rests and shifted measures) are
+// dropped on load.
 const STORAGE_KEY = "fifths-progression-v2";
 
 function isValidEntry(entry: unknown): entry is ProgressionEntry {
 	if (typeof entry !== "object" || entry === null) return false;
 	const candidate = entry as Partial<ProgressionEntry> & { beats?: unknown };
-	if (candidate.kind === "break") return true;
 	return (
 		candidate.kind === "chord" &&
 		typeof candidate.label === "string" &&
@@ -37,13 +41,10 @@ function loadEntries(): ProgressionEntry[] {
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		if (!Array.isArray(parsed)) return [];
-		return parsed
-			.filter(isValidEntry)
-			.map((entry: ProgressionEntry) =>
-				entry.kind === "chord"
-					? { ...entry, beats: normalizeBeats(entry.beats) }
-					: entry,
-			);
+		return parsed.filter(isValidEntry).map((entry: ProgressionEntry) => ({
+			...entry,
+			beats: normalizeBeats(entry.beats),
+		}));
 	} catch {
 		return [];
 	}
@@ -99,16 +100,7 @@ export function toggleRecording(): void {
 	progression.recording = !progression.recording;
 }
 
-// Start a new line in the jotted progression
-export function addLineBreak(): void {
-	// No leading or doubled breaks — they would render as empty lines
-	const last = progression.entries.at(-1);
-	if (!last || last.kind === "break") return;
-	progression.entries.push({ kind: "break" });
-	persist();
-}
-
-// Remove the most recent entry (chord or break)
+// Remove the most recent chord
 export function deleteLast(): void {
 	progression.entries.pop();
 	persist();

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -17,7 +17,6 @@ import {
 	stopMetronome,
 } from "$stores/metronome.svelte";
 import {
-	addLineBreak,
 	clearProgression,
 	progression,
 	recordChord,
@@ -245,20 +244,6 @@ describe("progression player", () => {
 		playProgression();
 		vi.advanceTimersByTime(STEP_MS);
 		expect(metronome.running).toBe(false);
-	});
-
-	it("rests on line breaks", () => {
-		recordChord("C", C_NOTES);
-		addLineBreak();
-		recordChord("G", G_NOTES);
-		playProgression();
-
-		vi.advanceTimersByTime(STEP_MS); // now on the break
-		expect(player.position).toBe(1);
-		expect(startChord).toHaveBeenCalledTimes(1); // no new chord
-
-		vi.advanceTimersByTime(STEP_MS); // now on G
-		expect(startChord).toHaveBeenCalledTimes(2);
 	});
 
 	it("releases each chord before the next step", () => {

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -103,7 +103,7 @@ function clearTimers(): void {
 }
 
 function entryBeats(entry: (typeof progression.entries)[number]): number {
-	return entry.kind === "chord" ? entry.beats : 1; // breaks rest one beat
+	return entry.beats;
 }
 
 // --- playback click ---------------------------------------------------------
@@ -156,7 +156,7 @@ function step(index: number): void {
 		scheduleStepClicks(entryBeats(entry));
 	}
 
-	if (entry.kind === "chord" && entry.notes.length > 0) {
+	if (entry.notes.length > 0) {
 		startChord(
 			entry.notes.map(midiToFrequency),
 			settings.activeVoice as OscillatorType,
@@ -166,7 +166,7 @@ function step(index: number): void {
 			stopChordById(PLAYBACK_POINTER_ID);
 		}, durationMs * GATE);
 	}
-	// Breaks (and legacy note-less chords) simply rest for their duration
+	// Legacy note-less chords simply rest for their duration
 
 	stepTimeout = setTimeout(() => step(index + 1), durationMs);
 }

--- a/src/lib/utils/midi.test.ts
+++ b/src/lib/utils/midi.test.ts
@@ -54,8 +54,6 @@ describe("progressionToMidi", () => {
 		notes: C_MAJOR_NOTES,
 		beats: 1,
 	};
-	const lineBreak: ProgressionEntry = { kind: "break" };
-
 	function bytesOf(entries: ProgressionEntry[]): number[] {
 		return Array.from(progressionToMidi(entries));
 	}
@@ -124,16 +122,14 @@ describe("progressionToMidi", () => {
 		]);
 	});
 
-	it("turns line breaks into one-quarter rests before the next chord", () => {
-		const single = bytesOf([cChord, cChord]);
-		const withBreak = bytesOf([cChord, lineBreak, cChord]);
-		// The second chord's first note-on delta grows from 0 to 480 (1 extra
-		// byte for the variable-length delta)
-		expect(withBreak.length).toBe(single.length + 1);
-		const secondOnDelta = withBreak.indexOf(0x90, 40);
-		expect(withBreak.slice(secondOnDelta - 2, secondOnDelta)).toEqual([
-			0x83, 0x60,
+	it("places consecutive chords back to back with no gap", () => {
+		const bytes = bytesOf([
+			{ kind: "chord", label: "A", notes: [69], beats: 1 },
+			{ kind: "chord", label: "B", notes: [71], beats: 1 },
 		]);
+		// Second chord's note-on has a zero delta (starts as the first ends)
+		const secondOn = bytes.indexOf(0x90, 34);
+		expect(bytes[secondOn - 1]).toBe(0x00);
 	});
 
 	it("skips legacy chords without note data", () => {

--- a/src/lib/utils/midi.ts
+++ b/src/lib/utils/midi.ts
@@ -56,8 +56,8 @@ function uint16(value: number): number[] {
 
 /**
  * Build a format-0 .mid file from progression entries.
- * Each chord lasts its recorded `beats` in quarter notes; line breaks become
- * one-quarter rests. Entries without note data (legacy jottings) are skipped.
+ * Each chord lasts its recorded `beats` in quarter notes.
+ * Entries without note data (legacy jottings) are skipped.
  */
 export function progressionToMidi(
 	entries: ProgressionEntry[],
@@ -77,25 +77,13 @@ export function progressionToMidi(
 		microsPerQuarter & 0xff,
 	);
 
-	// Delta time owed to the next event (accumulates across rests/skips)
-	let pendingDelta = 0;
-
 	for (const entry of entries) {
-		if (entry.kind === "break") {
-			pendingDelta += TICKS_PER_QUARTER;
-			continue;
-		}
 		if (entry.notes.length === 0) continue;
 
-		// Note-ons: first carries the pending delta, the rest are simultaneous
-		entry.notes.forEach((note, i) => {
-			events.push(
-				...encodeVariableLength(i === 0 ? pendingDelta : 0),
-				0x90,
-				note & 0x7f,
-				NOTE_VELOCITY,
-			);
-		});
+		// Note-ons are simultaneous at the previous chord's end
+		for (const note of entry.notes) {
+			events.push(...encodeVariableLength(0), 0x90, note & 0x7f, NOTE_VELOCITY);
+		}
 		// Note-offs after the chord's recorded duration
 		const durationTicks = entry.beats * TICKS_PER_QUARTER;
 		entry.notes.forEach((note, i) => {
@@ -106,7 +94,6 @@ export function progressionToMidi(
 				0x00,
 			);
 		});
-		pendingDelta = 0;
 	}
 
 	// End-of-track meta event


### PR DESCRIPTION
## Summary

Fixes the reported bug: the pad showed 4 chords per measure but playback delivered fewer per measure.

**Root cause**: line breaks silently played as one-beat rests and counted toward the accent/beat grid — the display treated them as pure visual organization, playback treated them as music. Every break shifted all following measures off the grid.

**Fix** (per discussion): breaks are removed as a concept.
- The **"new line"** button is gone; break entries no longer exist (legacy ones are dropped on load)
- Playback, click scheduling, and MIDI export operate on chords only — what you see is what plays
- The pad now **wraps by whole measures**: chords group into measures per the time signature, each measure is an unbreakable unit with its pipe, and lines wrap naturally between measures — a measure is never split across lines

## Test plan
- [x] 288 tests passing — measure-unit wrapping, multi-beat bar counting, back-to-back MIDI deltas, no new-line button
- [x] svelte-check, biome, build, fallow clean
- [ ] Manual: jot 8+ chords → pipes group by time signature, wrap keeps measures whole → play back with click → chords line up with the displayed measures