### PR TITLE
fix: repeated chords in playback skipped every second hit (v0.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-07-12
+
+### Fixed
+- Repeated identical chords in playback no longer skip every second hit ("4 quarter notes shown, 2 played"): a stopped chord's tracking entry lingered until a cleanup timer fired, so the same-chord dedup in `startChord` matched the stopped chord and silently swallowed the next repetition. Stopping a chord now removes its entry immediately; node teardown stays on the timer.
+
 ## [0.14.0] - 2026-07-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.14.0
+**Current Version**: 0.14.1
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -198,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.14.0</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.14.1</div>
 </div>

--- a/src/lib/stores/audio.svelte.test.ts
+++ b/src/lib/stores/audio.svelte.test.ts
@@ -366,6 +366,38 @@ describe("audio store", () => {
 			expect(audio.audioState.isPlaying).toBe(false);
 		});
 
+		// Regression: playback of repeated identical chords (quarter-note
+		// C C C C) restarts the same frequencies on the same pointer right
+		// after stopChordById. The pointer's map entry used to linger until
+		// the ~100ms cleanup timer, so startChord's same-chord dedup matched
+		// the STOPPED chord and silently skipped every second repetition —
+		// "4 chords shown, 2 played per measure".
+		it("replays the same chord immediately after it was stopped", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", -1);
+			audio.stopChordById(-1);
+
+			// Next playback step starts before the node-cleanup timer fires
+			await audio.startChord(C_MAJOR, "sine", -1);
+
+			const ctx = FakeAudioContext.instances[0];
+			// Two full soundings: 3 oscillators each
+			expect(ctx.createdOscillators).toHaveLength(6);
+			const secondHit = ctx.createdOscillators.slice(3);
+			for (const osc of secondHit) {
+				expect(osc.start).toHaveBeenCalled();
+			}
+		});
+
+		it("still dedups a chord that is actively sounding (not stopped)", async () => {
+			const audio = await freshStore();
+			await audio.startChord(C_MAJOR, "sine", 1);
+			await audio.startChord(C_MAJOR, "sine", 1); // same chord, still held
+
+			const ctx = FakeAudioContext.instances[0];
+			expect(ctx.createdOscillators).toHaveLength(3); // no restart
+		});
+
 		// Regression: sliding between wedges restarts the chord under the same
 		// pointer ID while the previous chord's fade cleanup is still pending.
 		// That cleanup used to delete the pointer's map entry unconditionally,

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -330,6 +330,14 @@ export function stopChordById(pointerId: number): void {
 	const chord = activeChords.get(pointerId);
 	if (!chord) return;
 
+	// A stopping chord is no longer "playing": remove its entry immediately
+	// so startChord's same-chord dedup cannot match it. (Deferring this to
+	// the cleanup timer made repeated identical chords — quarter-note C C C C
+	// in playback — skip every second hit, and once caused stuck drones when
+	// a replacement chord reused the pointer ID mid-fade.) Node teardown
+	// still happens on the timer below, via this closure's reference.
+	activeChords.delete(pointerId);
+
 	const fadeTime = 0.05;
 	const currentTime = audioContext.currentTime;
 
@@ -372,13 +380,6 @@ export function stopChordById(pointerId: number): void {
 				chord.chordGain.disconnect();
 			} catch {
 				// Already disconnected
-			}
-			// Only remove the map entry if it still belongs to the chord being
-			// cleaned up — a replacement chord (e.g. sliding between wedges)
-			// may have reused this pointer ID while the fade was in flight,
-			// and deleting its entry would orphan it as an unstoppable drone
-			if (activeChords.get(pointerId) === chord) {
-				activeChords.delete(pointerId);
 			}
 			audioState.activeNoteCount = activeOscillators.size;
 			audioState.isPlaying = activeOscillators.size > 0;


### PR DESCRIPTION
## Summary

Fixes the real root cause of "4 quarter notes shown, 2 played per measure."

Playback runs every step on the reserved pointer ID and releases each chord at 85% of the step. A stopped chord's `activeChords` entry lingered until the ~100ms node-cleanup timer — so when the next **identical** chord started (at 100% of the step, before the timer), `startChord`'s same-chord dedup matched the *stopped* chord and silently skipped it. Play–skip–play–skip. Distinct chords never hit the guard, which is why progressions with changing chords played fine.

`stopChordById` now removes the map entry immediately (a stopping chord is no longer "playing"); node teardown stays on the timer via the closure. This also structurally removes the deferred-delete race that v0.5.1 patched with an identity check.

## Test plan
- [x] 290 tests: new regressions (same chord restarts right after stop; actively-held chords still dedup) + the v0.5.1 slide-orphan test still passes
- [x] svelte-check, biome, build clean
- [ ] Manual: jot C C C C as quarter notes → play back → four hits per measure