### PR TITLE
feat: capture rests between chords (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-07-13
+
+### Added
+- Rests: the silence between a release and the next press is now captured as part of the rhythm. Gaps under half a beat read as articulation (ignored); gaps up to 8 beats quantize to 1/2/4-beat rests (capped at a bar); longer pauses read as thinking time. Rests appear as dimmed dashes in the pad, count toward measures, play back as silence (the click still marks their beats), export as MIDI gaps, and are removable with undo. Rests never lead a progression and are not recorded while another chord is still sounding.
+
 ## [0.14.1] - 2026-07-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Fifths (chord-player) is an interactive web application that visualizes and play
 
 **Documentation**: All documentation and planning files should be placed in the `/docs` folder
 
-**Current Version**: 0.14.1
+**Current Version**: 0.15.0
 **Feature Roadmap**: See docs/FEATURES.md for planned enhancements
 
 **Frequency Generation**: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"author": "Kevin Peckham",
 	"name": "chord-player",
-	"version": "0.14.1",
+	"version": "0.15.0",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.1",
 		"@sveltejs/adapter-vercel": "6.3.4",

--- a/src/lib/components/Instrument.svelte
+++ b/src/lib/components/Instrument.svelte
@@ -26,7 +26,11 @@ import {
 	unlockAudio,
 } from "$stores/audio.svelte";
 import { performance } from "$stores/performance.svelte";
-import { recordChord, setEntryBeats } from "$stores/progression.svelte";
+import {
+	recordChord,
+	recordRest,
+	setEntryBeats,
+} from "$stores/progression.svelte";
 import { player } from "$stores/progressionPlayer.svelte";
 import { settings } from "$stores/settings.svelte";
 
@@ -46,7 +50,7 @@ import { textCoords, wedgePath } from "$utils/circleGeometry";
 import { processChordEnharmonics } from "$utils/enharmonics";
 import { frequenciesToMidi } from "$utils/midi";
 import { CHROMATIC_NOTES, getNoteForPosition } from "$utils/noteHelpers";
-import { beatsFromHold } from "$utils/rhythm";
+import { beatsFromHold, restBeatsFromGap } from "$utils/rhythm";
 import { seventhChordName, withSeventh } from "$utils/sevenths";
 
 // A jotted entry whose hold duration is still open (finalized on release)
@@ -169,6 +173,7 @@ function playChordAtIndex(index: number, mode: string, pointerId: number) {
 	const chordName = chordDisplayName(datum, mode, seventh);
 	if (pointerInfo && chordName !== pointerInfo.chordName) {
 		closeOpenRecord(pointerInfo);
+		maybeRecordRestGap();
 		const index = recordChord(
 			chordSymbol(datum, mode, seventh),
 			frequenciesToMidi(frequencies),
@@ -182,6 +187,9 @@ function playChordAtIndex(index: number, mode: string, pointerId: number) {
 	startChord(frequencies, settings.activeVoice as OscillatorType, pointerId);
 }
 
+// When the last recorded chord was released, for rest-gap detection
+let lastRecordedReleaseAt: number | null = null;
+
 // Finalize an open pad entry's duration from how long it was held,
 // quantized to the pad's tempo
 function closeOpenRecord(pointerInfo: { openRecord: OpenRecord | null }) {
@@ -192,6 +200,29 @@ function closeOpenRecord(pointerInfo: { openRecord: OpenRecord | null }) {
 		beatsFromHold(heldMs, player.bpm),
 	);
 	pointerInfo.openRecord = null;
+	lastRecordedReleaseAt = Date.now();
+}
+
+// True while any pointer is holding a recorded chord open
+function anyOpenRecords(): boolean {
+	for (const info of activePointers.values()) {
+		if (info.openRecord) return true;
+	}
+	return false;
+}
+
+// Capture the silence since the last recorded release as a rest. Slides and
+// seventh changes close their record in the same tick (zero gap), other
+// sounding pointers suppress it, and restBeatsFromGap ignores both
+// articulation gaps and walked-away pauses.
+function maybeRecordRestGap() {
+	if (lastRecordedReleaseAt === null) return;
+	if (anyOpenRecords()) return;
+	const beats = restBeatsFromGap(
+		Date.now() - lastRecordedReleaseAt,
+		player.bpm,
+	);
+	if (beats !== 0) recordRest(beats);
 }
 
 function playChordFromElement(element: SVGPathElement, pointerId: number) {

--- a/src/lib/components/Instrument.svelte.test.ts
+++ b/src/lib/components/Instrument.svelte.test.ts
@@ -425,6 +425,77 @@ describe("Instrument", () => {
 			]);
 		});
 
+		it("captures silence between chords as a rest", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			const gWedge = container.querySelector('[id="chord-button-G"]');
+			if (!cWedge || !gWedge) throw new Error("wedges not found");
+
+			await pressChord(cWedge, 1);
+			releasePointer(cWedge, 1);
+			await tick();
+
+			// A two-beat silence at 120 BPM, then the next chord
+			vi.advanceTimersByTime(1000);
+			gWedge.dispatchEvent(pointerEvent("pointerdown", 1));
+			await tick();
+
+			expect(progression.entries.map((e) => e.kind)).toEqual([
+				"chord",
+				"rest",
+				"chord",
+			]);
+			expect(progression.entries[1]).toEqual({ kind: "rest", beats: 2 });
+		});
+
+		it("does not record a rest for short articulation gaps", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			const gWedge = container.querySelector('[id="chord-button-G"]');
+			if (!cWedge || !gWedge) throw new Error("wedges not found");
+
+			await pressChord(cWedge, 1);
+			releasePointer(cWedge, 1);
+			await tick();
+
+			vi.advanceTimersByTime(100); // < half a beat
+			gWedge.dispatchEvent(pointerEvent("pointerdown", 1));
+			await tick();
+
+			expect(progression.entries.map((e) => e.kind)).toEqual([
+				"chord",
+				"chord",
+			]);
+		});
+
+		it("does not record a rest while another chord is still sounding", async () => {
+			const { container } = render(Instrument, { chords: chordsData });
+			const cWedge = container.querySelector('[id="chord-button-C"]');
+			const gWedge = container.querySelector('[id="chord-button-G"]');
+			const fWedge = container.querySelector('[id="chord-button-F"]');
+			if (!cWedge || !gWedge || !fWedge) throw new Error("wedges not found");
+
+			await pressChord(cWedge, 1);
+			releasePointer(cWedge, 1);
+			await tick();
+
+			vi.advanceTimersByTime(1000);
+			// G starts (a rest is jotted for the gap) and KEEPS sounding
+			gWedge.dispatchEvent(pointerEvent("pointerdown", 1));
+			await tick();
+			vi.advanceTimersByTime(1000);
+			// F on a second finger while G holds: no rest despite the time gap
+			fWedge.dispatchEvent(pointerEvent("pointerdown", 2));
+			await tick();
+
+			expect(progression.entries.map((e) => e.kind)).toEqual([
+				"chord",
+				"rest",
+				"chord",
+				"chord",
+			]);
+		});
+
 		it("quantizes a chord's held duration into beats on release", async () => {
 			const { container } = render(Instrument, { chords: chordsData });
 			const cWedge = container.querySelector('[id="chord-button-C"]');

--- a/src/lib/components/ProgressionPad.svelte
+++ b/src/lib/components/ProgressionPad.svelte
@@ -30,12 +30,13 @@ import {
 } from "$stores/progressionPlayer.svelte";
 import { beatsPerBar, settings } from "$stores/settings.svelte";
 
-// Group chords into measures (per the time signature), keeping each chord's
-// index into progression.entries so the sounding chord can be highlighted.
+// Group entries into measures (per the time signature), keeping each entry's
+// index into progression.entries so the sounding step can be highlighted.
+// Rests appear as dimmed dashes and count toward the bar like chords.
 // Each measure renders as an unbreakable unit, so wrapping never splits one.
 const measures = $derived.by(() => {
 	const barBeats = beatsPerBar();
-	const grouped: { label: string; index: number }[][] = [[]];
+	const grouped: { label: string; index: number; rest: boolean }[][] = [[]];
 	let beatsInBar = 0;
 
 	progression.entries.forEach((entry, index) => {
@@ -43,7 +44,11 @@ const measures = $derived.by(() => {
 			grouped.push([]);
 			beatsInBar = beatsInBar % barBeats;
 		}
-		grouped[grouped.length - 1].push({ label: entry.label, index });
+		grouped[grouped.length - 1].push({
+			label: entry.kind === "chord" ? entry.label : "–",
+			index,
+			rest: entry.kind === "rest",
+		});
 		beatsInBar += entry.beats;
 	});
 	return grouped;
@@ -94,9 +99,12 @@ const activeClasses = "text-accent border-accent/60";
 				<div data-measure class="flex gap-x-3 whitespace-nowrap">
 					{#each measure as chip}
 						<span
+							title={chip.rest ? "rest" : undefined}
 							class={player.position === chip.index
 								? "text-accent"
-								: "opacity-90"}
+								: chip.rest
+									? "opacity-40"
+									: "opacity-90"}
 						>{chip.label}</span>
 					{/each}
 					{#if m < measures.length - 1}

--- a/src/lib/components/ProgressionPad.svelte.test.ts
+++ b/src/lib/components/ProgressionPad.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	clearProgression,
 	progression,
 	recordChord,
+	recordRest,
 	setEntryBeats,
 } from "$stores/progression.svelte";
 import { player, setBpm, stopPlayback } from "$stores/progressionPlayer.svelte";
@@ -121,6 +122,20 @@ describe("ProgressionPad", () => {
 			screen.getByLabelText("Jotted progression").querySelectorAll("span"),
 		).map((span) => span.textContent);
 		expect(chips).toEqual(["C", "F", "G", "Am", "|", "C"]);
+	});
+
+	it("shows rests as dashes that count toward the measure", () => {
+		settings.timeSignature = "4/4";
+		recordChord("C", [60]);
+		recordRest(2);
+		recordChord("G", [55]); // 1 + 2 + 1 beats complete the bar
+		recordChord("Am", [57]); // starts the next measure
+		render(ProgressionPad);
+
+		const chips = Array.from(
+			screen.getByLabelText("Jotted progression").querySelectorAll("span"),
+		).map((span) => span.textContent);
+		expect(chips).toEqual(["C", "–", "G", "|", "Am"]);
 	});
 
 	it("counts multi-beat chords toward the bar", async () => {

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -198,5 +198,5 @@ const reverbPercent = $derived(Math.round(audioState.reverbMix * 100));
 	</div>
 
 	<!-- version -->
-	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.14.1</div>
+	<div class="absolute right-8 bottom-8 opacity-60 text-xs">v0.15.0</div>
 </div>

--- a/src/lib/stores/progression.svelte.test.ts
+++ b/src/lib/stores/progression.svelte.test.ts
@@ -5,6 +5,7 @@ import {
 	deleteLast,
 	progression,
 	recordChord,
+	recordRest,
 	setEntryBeats,
 	toggleRecording,
 } from "$stores/progression.svelte";
@@ -78,6 +79,32 @@ describe("progression store", () => {
 			{ kind: "chord", label: "C", notes: [], beats: 1 },
 			{ kind: "chord", label: "Am", notes: [], beats: 1 },
 			{ kind: "chord", label: "F7", notes: [], beats: 1 },
+		]);
+	});
+
+	it("records rests between chords, but never leading and never while off", () => {
+		recordRest(2); // leading — ignored
+		expect(progression.entries).toEqual([]);
+
+		recordChord("C");
+		recordRest(2);
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
+			{ kind: "rest", beats: 2 },
+		]);
+		expect(stored()).toHaveLength(2);
+
+		toggleRecording();
+		recordRest(1); // rec off — ignored
+		expect(progression.entries).toHaveLength(2);
+	});
+
+	it("undo removes a rest like any entry", () => {
+		recordChord("C");
+		recordRest(1);
+		deleteLast();
+		expect(progression.entries).toEqual([
+			{ kind: "chord", label: "C", notes: [], beats: 1 },
 		]);
 	});
 

--- a/src/lib/stores/progression.svelte.ts
+++ b/src/lib/stores/progression.svelte.ts
@@ -3,12 +3,12 @@
 
 import type { ChordBeats } from "$utils/rhythm";
 
-export type ProgressionEntry = {
-	kind: "chord";
-	label: string;
-	notes: number[];
-	beats: ChordBeats;
-};
+export type ProgressionEntry =
+	| { kind: "chord"; label: string; notes: number[]; beats: ChordBeats }
+	// Captured silence between chords — unlike the removed visual "break",
+	// a rest is musical: it counts toward measures, plays back as silence,
+	// clicks along, and exports as a MIDI gap
+	| { kind: "rest"; beats: ChordBeats };
 
 // v2: chord entries carry MIDI note numbers (for playback and .mid export).
 // The key was bumped from "fifths-progression", intentionally abandoning
@@ -20,7 +20,12 @@ const STORAGE_KEY = "fifths-progression-v2";
 
 function isValidEntry(entry: unknown): entry is ProgressionEntry {
 	if (typeof entry !== "object" || entry === null) return false;
-	const candidate = entry as Partial<ProgressionEntry> & { beats?: unknown };
+	const candidate = entry as {
+		kind?: unknown;
+		label?: unknown;
+		notes?: unknown;
+	};
+	if (candidate.kind === "rest") return true;
 	return (
 		candidate.kind === "chord" &&
 		typeof candidate.label === "string" &&
@@ -43,7 +48,7 @@ function loadEntries(): ProgressionEntry[] {
 		if (!Array.isArray(parsed)) return [];
 		return parsed.filter(isValidEntry).map((entry: ProgressionEntry) => ({
 			...entry,
-			beats: normalizeBeats(entry.beats),
+			beats: normalizeBeats((entry as { beats?: unknown }).beats),
 		}));
 	} catch {
 		return [];
@@ -85,6 +90,15 @@ export function recordChord(label: string, notes: number[] = []): number {
 	progression.entries.push({ kind: "chord", label, notes, beats: 1 });
 	persist();
 	return progression.entries.length - 1;
+}
+
+// Record captured silence between chords. Rests never lead a progression —
+// a leading gap is just the player getting ready.
+export function recordRest(beats: ChordBeats): void {
+	if (!shouldRecord()) return;
+	if (progression.entries.length === 0) return;
+	progression.entries.push({ kind: "rest", beats });
+	persist();
 }
 
 // Set a chord's duration once its hold length is known (on release/slide)

--- a/src/lib/stores/progressionPlayer.svelte.test.ts
+++ b/src/lib/stores/progressionPlayer.svelte.test.ts
@@ -20,6 +20,7 @@ import {
 	clearProgression,
 	progression,
 	recordChord,
+	recordRest,
 	setEntryBeats,
 } from "$stores/progression.svelte";
 import {
@@ -244,6 +245,35 @@ describe("progression player", () => {
 		playProgression();
 		vi.advanceTimersByTime(STEP_MS);
 		expect(metronome.running).toBe(false);
+	});
+
+	it("rests are silent for their beats, then playback continues", () => {
+		recordChord("C", C_NOTES);
+		recordRest(2);
+		recordChord("G", G_NOTES);
+		playProgression();
+
+		vi.advanceTimersByTime(STEP_MS); // now on the rest
+		expect(player.position).toBe(1);
+		expect(startChord).toHaveBeenCalledTimes(1); // nothing new sounds
+
+		vi.advanceTimersByTime(STEP_MS); // rest is 2 beats — still resting
+		expect(player.position).toBe(1);
+
+		vi.advanceTimersByTime(STEP_MS); // now on G
+		expect(player.position).toBe(2);
+		expect(startChord).toHaveBeenCalledTimes(2);
+	});
+
+	it("the playback click marks rest beats too", () => {
+		player.clickAlong = true;
+		recordChord("C", C_NOTES);
+		recordRest(2);
+		playProgression();
+		vi.advanceTimersByTime(STEP_MS * 3);
+
+		// 1 beat for C + 2 for the rest
+		expect(vi.mocked(scheduleClick).mock.calls).toHaveLength(3);
 	});
 
 	it("releases each chord before the next step", () => {

--- a/src/lib/stores/progressionPlayer.svelte.ts
+++ b/src/lib/stores/progressionPlayer.svelte.ts
@@ -156,7 +156,7 @@ function step(index: number): void {
 		scheduleStepClicks(entryBeats(entry));
 	}
 
-	if (entry.notes.length > 0) {
+	if (entry.kind === "chord" && entry.notes.length > 0) {
 		startChord(
 			entry.notes.map(midiToFrequency),
 			settings.activeVoice as OscillatorType,
@@ -166,7 +166,8 @@ function step(index: number): void {
 			stopChordById(PLAYBACK_POINTER_ID);
 		}, durationMs * GATE);
 	}
-	// Legacy note-less chords simply rest for their duration
+	// Rests (and legacy note-less chords) are silent for their duration —
+	// the click above still marks their beats
 
 	stepTimeout = setTimeout(() => step(index + 1), durationMs);
 }

--- a/src/lib/utils/midi.test.ts
+++ b/src/lib/utils/midi.test.ts
@@ -132,6 +132,18 @@ describe("progressionToMidi", () => {
 		expect(bytes[secondOn - 1]).toBe(0x00);
 	});
 
+	it("advances the clock silently across rests", () => {
+		const bytes = bytesOf([
+			{ kind: "chord", label: "A", notes: [69], beats: 1 },
+			{ kind: "rest", beats: 2 },
+			{ kind: "chord", label: "B", notes: [71], beats: 1 },
+		]);
+		// Second chord's note-on carries the rest delta: 2 quarters = 960
+		// ticks = VLQ 0x87 0x40
+		const secondOn = bytes.indexOf(0x90, 34);
+		expect(bytes.slice(secondOn - 2, secondOn)).toEqual([0x87, 0x40]);
+	});
+
 	it("skips legacy chords without note data", () => {
 		const bytes = bytesOf([{ kind: "chord", label: "C", notes: [], beats: 1 }]);
 		expect(bytes.filter((b) => b === 0x90)).toHaveLength(0);

--- a/src/lib/utils/midi.ts
+++ b/src/lib/utils/midi.ts
@@ -56,8 +56,8 @@ function uint16(value: number): number[] {
 
 /**
  * Build a format-0 .mid file from progression entries.
- * Each chord lasts its recorded `beats` in quarter notes.
- * Entries without note data (legacy jottings) are skipped.
+ * Each chord lasts its recorded `beats` in quarter notes; rests advance the
+ * clock silently. Chords without note data (legacy jottings) are skipped.
  */
 export function progressionToMidi(
 	entries: ProgressionEntry[],
@@ -77,13 +77,26 @@ export function progressionToMidi(
 		microsPerQuarter & 0xff,
 	);
 
+	// Delta time owed to the next note-on (accumulates across rests/skips)
+	let pendingDelta = 0;
+
 	for (const entry of entries) {
+		if (entry.kind === "rest") {
+			pendingDelta += entry.beats * TICKS_PER_QUARTER;
+			continue;
+		}
 		if (entry.notes.length === 0) continue;
 
-		// Note-ons are simultaneous at the previous chord's end
-		for (const note of entry.notes) {
-			events.push(...encodeVariableLength(0), 0x90, note & 0x7f, NOTE_VELOCITY);
-		}
+		// Note-ons: the first carries any pending rest delta, the rest of the
+		// chord's notes are simultaneous
+		entry.notes.forEach((note, i) => {
+			events.push(
+				...encodeVariableLength(i === 0 ? pendingDelta : 0),
+				0x90,
+				note & 0x7f,
+				NOTE_VELOCITY,
+			);
+		});
 		// Note-offs after the chord's recorded duration
 		const durationTicks = entry.beats * TICKS_PER_QUARTER;
 		entry.notes.forEach((note, i) => {
@@ -94,6 +107,7 @@ export function progressionToMidi(
 				0x00,
 			);
 		});
+		pendingDelta = 0;
 	}
 
 	// End-of-track meta event

--- a/src/lib/utils/rhythm.test.ts
+++ b/src/lib/utils/rhythm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { beatMs, beatsFromHold } from "./rhythm";
+import { beatMs, beatsFromHold, restBeatsFromGap } from "./rhythm";
 
 describe("beatMs", () => {
 	it("converts BPM to milliseconds per beat", () => {
@@ -32,5 +32,25 @@ describe("beatsFromHold", () => {
 		// 1000ms is one beat at 60 BPM (stab) but four beats at 240 BPM
 		expect(beatsFromHold(1000, 60)).toBe(1);
 		expect(beatsFromHold(1000, 240)).toBe(4);
+	});
+});
+
+describe("restBeatsFromGap", () => {
+	// At 120 BPM one beat is 500ms
+	it("ignores articulation gaps under half a beat", () => {
+		expect(restBeatsFromGap(0, 120)).toBe(0);
+		expect(restBeatsFromGap(240, 120)).toBe(0);
+	});
+
+	it("quantizes musical gaps to 1, 2, or 4 beats", () => {
+		expect(restBeatsFromGap(500, 120)).toBe(1); // one beat of silence
+		expect(restBeatsFromGap(1000, 120)).toBe(2);
+		expect(restBeatsFromGap(2000, 120)).toBe(4);
+		expect(restBeatsFromGap(4000, 120)).toBe(4); // capped at a bar (8 beats)
+	});
+
+	it("treats long pauses as thinking time, not rests", () => {
+		expect(restBeatsFromGap(4100, 120)).toBe(0); // > 8 beats
+		expect(restBeatsFromGap(30_000, 120)).toBe(0);
 	});
 });

--- a/src/lib/utils/rhythm.ts
+++ b/src/lib/utils/rhythm.ts
@@ -25,3 +25,18 @@ export function beatsFromHold(heldMs: number, bpm: number): ChordBeats {
 	if (beats < 3) return 2;
 	return 4;
 }
+
+/**
+ * Quantize the silence between a release and the next press into a rest.
+ * Under half a beat is articulation (no rest); up to 8 beats quantizes to
+ * 1/2/4 beats (capped at a whole 4/4 bar); anything longer reads as
+ * thinking time, not music, and records nothing.
+ */
+export function restBeatsFromGap(gapMs: number, bpm: number): ChordBeats | 0 {
+	const beats = gapMs / beatMs(bpm);
+	if (beats < 0.5) return 0;
+	if (beats < 1.5) return 1;
+	if (beats < 3) return 2;
+	if (beats <= 8) return 4;
+	return 0;
+}


### PR DESCRIPTION
## Summary

Closes the rhythm-capture gap: chord holds were quantized to beats but the **silence between chords was discarded**, collapsing staccato patterns and deliberate rests into wall-to-wall playback.

- **Gap quantization** mirrors hold quantization: under ½ beat = articulation (ignored); up to 8 beats = a 1/2/4-beat rest (capped at a bar); longer = thinking time, ignored
- Rests are first-class musical entries: dimmed **–** chips in the pad that count toward measures, silent beats in playback (the click still marks them), MIDI delta gaps on export, removable with undo
- Guards: rests never lead a progression, never record while another pointer's chord is still sounding, and slides/seventh-changes produce zero gap by construction

## Test plan
- [x] 302 tests passing (+12): rhythm thresholds, store guards, silent playback + click beats, MIDI rest deltas, pad rendering, Instrument gap detection incl. multi-pointer suppression
- [x] svelte-check, biome, build clean
- [ ] Manual: play chord–pause–chord → dash appears, measure math includes it, playback breathes where you did